### PR TITLE
Apply a display name to the new passkey

### DIFF
--- a/src/server/libs/users.ts
+++ b/src/server/libs/users.ts
@@ -45,11 +45,11 @@ export interface User {
 
 export interface SignUpUser {
   username: string;
+  passkeyUserId: PasskeyUserId;
   displayName?: string;
   email?: string;
   picture?: string;
   password?: string;
-  passkeyUserId?: PasskeyUserId;
 }
 
 /**

--- a/src/server/libs/users.ts
+++ b/src/server/libs/users.ts
@@ -45,7 +45,7 @@ export interface User {
 
 export interface SignUpUser {
   username: string;
-  passkeyUserId: PasskeyUserId;
+  passkeyUserId?: PasskeyUserId;
   displayName?: string;
   email?: string;
   picture?: string;

--- a/src/server/middlewares/auth.ts
+++ b/src/server/middlewares/auth.ts
@@ -16,7 +16,11 @@
  */
 import {Router, Request, Response} from 'express';
 
-import {Users, SignUpUser} from '~project-sesame/server/libs/users.ts';
+import {
+  generatePasskeyUserId,
+  Users,
+  SignUpUser,
+} from '~project-sesame/server/libs/users.ts';
 import {
   UserSignInStatus,
   setSignedIn,
@@ -41,9 +45,13 @@ router.post(
   apiAclCheck(ApiType.NoAuth),
   async (req: Request, res: Response) => {
     const {username, 'display-name': displayName} = req.body;
+
     // TODO: Use Captcha to block bots.
 
     try {
+      // TODO: Validate the display name
+      const trimmedDisplayName = displayName.trim();
+
       // Only check username, no need to check password as this is a mock
       if (Users.isValidUsername(username)) {
         // See if account already exists
@@ -56,11 +64,14 @@ router.post(
             .send({error: 'The username is already taken.'});
         }
 
+        const passkeyUserId = generatePasskeyUserId();
+
         // Set username in the session
         setSigningUp(
           {
             username,
-            displayName,
+            displayName: trimmedDisplayName,
+            passkeyUserId,
           },
           req,
           res

--- a/src/server/middlewares/session.ts
+++ b/src/server/middlewares/session.ts
@@ -353,73 +353,6 @@ export function deleteChallenge(req: Request, res: Response): void {
 }
 
 /**
- * Sets the ephemeral passkey user ID in the session.
- * This is used during the sign-up process before the user is fully created.
- *
- * @param passkey_user_id - The passkey user ID to set.
- * @param req - The request object.
- * @param res - The response object.
- * @throws Error if `passkey_user_id` is invalid.
- */
-export function setEphemeralPasskeyUserId(
-  passkey_user_id: string,
-  req: Request,
-  res: Response
-): void {
-  if (!passkey_user_id) {
-    throw new Error('Invalid passkey_user_id.');
-  }
-  req.session.passkey_user_id = passkey_user_id;
-  return;
-}
-
-/**
- * Retrieves the ephemeral passkey user ID from the session.
- * This is used during the sign-up process before the user is fully created.
- *
- * @param req - The request object.
- * @param res - The response object.
- * @returns The ephemeral passkey user ID, or undefined if not set.
- */
-export function getEphemeralPasskeyUserId(
-  req: Request,
-  res: Response
-): string | undefined {
-  if (req.session.passkey_user_id) {
-    return req.session.passkey_user_id;
-  } else {
-    // TODO: Generate a passkey user id
-    console.log('TODO: passkey user id does not exist yet.');
-    return undefined;
-  }
-}
-
-/**
- * Deletes the ephemeral passkey user ID from the session.
- * This is used after the user is fully created during the sign-up process.
- *
- * @param req - The request object.
- * @param res - The response object.
- */
-export function deleteEpehemeralPasskeyUserId(
-  req: Request,
-  res: Response
-): void {
-  delete req.session.passkey_user_id;
-  return;
-}
-
-// export function setSigningUp(req: Request, res: Response): void {
-//   req.session.signing_up = true;
-//   return;
-// }
-
-// export function unsetSigningUp(req: Request, res: Response): void {
-//   delete req.session.signing_up;
-//   return;
-// }
-
-/**
  * Sets the username in the session during the sign-up process.
  * TODO: Move this to database instead of session, eventually.
  *
@@ -429,19 +362,12 @@ export function deleteEpehemeralPasskeyUserId(
  * @throws Error if `username` is invalid.
  */
 export function setSigningUp(
-  user: {username: string; displayName?: string},
+  user: SignUpUser,
   req: Request,
   res: Response
 ): void {
-  const {username, displayName} = user;
-  if (!username) {
-    throw new Error('Invalid username.');
-  }
-  req.session.signup_username = username; // TODO: deprecate
-  req.session.signup_user = {
-    username,
-    displayName,
-  };
+  req.session.signup_username = user.username; // TODO: deprecate
+  req.session.signup_user = user;
   return;
 }
 
@@ -516,7 +442,6 @@ export function resetSigningIn(req: Request, res: Response): void {
  */
 export function setSignedIn(user: User, req: Request, res: Response): void {
   deleteChallenge(req, res);
-  deleteEpehemeralPasskeyUserId(req, res);
   resetSigningIn(req, res);
   resetSigningUp(req, res);
 

--- a/src/shared/views/passkey-signup.html
+++ b/src/shared/views/passkey-signup.html
@@ -64,7 +64,7 @@ app](https://goo.gle/passkeys-codelab)
       id="username"
       name="username"
       autocomplete="username"
-      label="Username"
+      label="Username *"
       variant="outlined"
       autofocus
     >


### PR DESCRIPTION
The previous pull request only applied a display name to the newly created account. In this pull request, the display name is applied to the newly created passkey if it's created along with the account.