### PR TITLE
Use camel case instead of kebab case for endpoint consistency

### DIFF
--- a/src/server/middlewares/auth.ts
+++ b/src/server/middlewares/auth.ts
@@ -44,7 +44,7 @@ router.post(
   '/new-user',
   apiAclCheck(ApiType.NoAuth),
   async (req: Request, res: Response) => {
-    const {username, 'display-name': displayName} = req.body;
+    const {username, displayName = ''} = req.body;
 
     // TODO: Use Captcha to block bots.
 
@@ -125,12 +125,7 @@ router.post(
   '/new-username-password',
   apiAclCheck(ApiType.NoAuth),
   async (req: Request, res: Response) => {
-    const {
-      username,
-      'display-name': displayName,
-      password1,
-      password2,
-    } = req.body;
+    const {username, displayName, password1, password2} = req.body;
 
     if (!Users.isValidUsername(username)) {
       return res.status(400).json({error: 'Invalid username'});

--- a/src/server/middlewares/webauthn.ts
+++ b/src/server/middlewares/webauthn.ts
@@ -133,7 +133,7 @@ router.post(
   apiAclCheck(ApiType.PasskeyRegistration),
   async (req: Request, res: Response) => {
     let passkeyUserId, username, displayName;
-    const non_platform = !!req.query.non_platform;
+    const non_platform = 'non_platform' in req.query;
     if (res.locals.signin_status === UserSignInStatus.SigningUp) {
       username = res.locals.username;
       const signup_user = getSigningUp(req, res);
@@ -226,7 +226,7 @@ router.post(
     }
 
     // Set expected values.
-    const conditional = !!req.query.conditional;
+    const conditional = 'conditional' in req.query;
     const response = <RegistrationResponseJSON>req.body;
     const expectedChallenge = getChallenge(req, res);
     const expectedOrigin = config.associated_origins;

--- a/src/shared/views/passkey-signup.html
+++ b/src/shared/views/passkey-signup.html
@@ -72,7 +72,7 @@ app](https://goo.gle/passkeys-codelab)
     <mdui-text-field
       type="text"
       id="display-name"
-      name="display-name"
+      name="displayName"
       label="Display name"
       variant="outlined"
     >

--- a/src/shared/views/signup-form.html
+++ b/src/shared/views/signup-form.html
@@ -53,7 +53,7 @@ Append `autocomplete="username"` attribute for `username` field. Append
     <mdui-text-field
       type="text"
       id="display-name"
-      name="display-name"
+      name="displayName"
       label="Display name"
       variant="outlined"
     >


### PR DESCRIPTION
- Use camel case instead of kebab case for endpoint consistency for `display-name`
- A bug fix