### PR TITLE
Fix passkey autofocus issue in client helpers

### DIFF
--- a/src/client/helpers/index.ts
+++ b/src/client/helpers/index.ts
@@ -251,17 +251,17 @@ class Loading {
 
   start() {
     delete this.progress.value;
-    const inputs = document.querySelectorAll('mdui-text-field');
+    const inputs = document.querySelectorAll('mdui-text-field, input');
     if (inputs) {
-      inputs.forEach(input => (input.disabled = true));
+      inputs.forEach(input => ((<any>input).disabled = true));
     }
   }
 
   stop() {
     this.progress.value = 0;
-    const inputs = document.querySelectorAll('mdui-text-field');
+    const inputs = document.querySelectorAll('mdui-text-field, input');
     if (inputs) {
-      inputs.forEach(input => (input.disabled = false));
+      inputs.forEach(input => ((<any>input).disabled = false));
     }
   }
 }


### PR DESCRIPTION
### Description

This PR updates the `Loading` helper class in `src/client/helpers/index.ts` to correctly manage standard HTML `input` elements alongside `mdui-text-field` web components.

The "Passkey form autofill" flow (`passkey-form-autofill.html`) relies on the `autofocus` attribute to automatically trigger the browser's WebAuthn conditional UI (the passkey selection prompt) immediately upon page load.

Previously, the `Loading` helper used in the client logic only targeted `mdui-text-field` elements when toggling the `disabled` state. This resulted in incomplete state management for forms containing standard `<input>` tags (such as hidden password fields or fallback inputs). This state inconsistency prevented the autofocus behavior from correctly triggering the passkey prompt.

### Changes

*   **`src/client/helpers/index.ts`**
    *   Updated the `querySelectorAll` selector in both `start()` and `stop()` methods to target `mdui-text-field, input` instead of just `mdui-text-field`.
    *   Added type casting to ensure the `disabled` property is correctly applied to both element types.

### Testing

1.  Navigate to the "Passkey form autofill" page (`/passkey-form-autofill`).
2.  Ensure you have a passkey saved for this domain.
3.  Refresh the page.
4.  **Observe**: The browser's passkey autofill prompt should appear automatically over the username field without requiring a user click.
