### PR TITLE
Add an infrastructure to auto-generate documents

### DIFF
--- a/.github/workflows/deploy-to-prod.yaml
+++ b/.github/workflows/deploy-to-prod.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Deploy to Google App Engine
 
 # This section defines when the workflow will be triggered.

--- a/.github/workflows/deploy-to-staging.yaml
+++ b/.github/workflows/deploy-to-staging.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Deploy to Google App Engine
 
 # This section defines when the workflow will be triggered.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
         "@rsbuild/plugin-sass": "^1.3.1",
         "@types/cookie-parser": "^1.4.8",
         "@types/cors": "^2.8.19",
+        "@types/swagger-jsdoc": "^6.0.4",
+        "@types/swagger-ui-express": "^4.1.8",
         "esbuild": "0.25.3",
         "firebase-tools": "14.2.2",
         "gts": "6.0.2",
@@ -39,6 +41,9 @@
         "mdui": "^2.1.3",
         "nodemon": "3.1.10",
         "rimraf": "6.0.1",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1",
+        "typedoc": "^0.28.15",
         "ua-parser-js": "^1.0.40",
         "webauthn-polyfills": "^0.1.7"
       },
@@ -85,6 +90,41 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -929,6 +969,20 @@
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.20.0.tgz",
+      "integrity": "sha512-Wa57i+bMpK6PGJZ1f2myxo3iO+K/kZikcyvH8NIqNNZhQUbDav7V9LQmWOXhf946mz5c1NZ19WMsGYiDKTryzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.20.0",
+        "@shikijs/langs": "^3.20.0",
+        "@shikijs/themes": "^3.20.0",
+        "@shikijs/types": "^3.20.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
     },
     "node_modules/@google-cloud/cloud-sql-connector": {
       "version": "1.3.4",
@@ -2433,6 +2487,63 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.20.0.tgz",
+      "integrity": "sha512-Yx3gy7xLzM0ZOjqoxciHjA7dAt5tyzJE3L4uQoM83agahy+PlW244XJSrmJRSBvGYELDhYXPacD4R/cauV5bzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.20.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.20.0.tgz",
+      "integrity": "sha512-le+bssCxcSHrygCWuOrYJHvjus6zhQ2K7q/0mgjiffRbkhM4o1EWu2m+29l0yEsHDbWaWPNnDUTRVVBvBBeKaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.20.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.20.0.tgz",
+      "integrity": "sha512-U1NSU7Sl26Q7ErRvJUouArxfM2euWqq1xaSrbqMu2iqa+tSp0D1Yah8216sDYbdDHw4C8b75UpE65eWorm2erQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.20.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.20.0.tgz",
+      "integrity": "sha512-lhYAATn10nkZcBQ0BlzSbJA3wcmL5MXUUF8d2Zzon6saZDlToKaiRX60n2+ZaHJCmXEcZRWNzn+k9vplr8Jhsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -2594,6 +2705,16 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -2718,6 +2839,24 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/swagger-jsdoc": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
+      "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
+    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -2740,6 +2879,13 @@
       "version": "0.7.39",
       "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.39.tgz",
       "integrity": "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4976,6 +5122,19 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -8257,6 +8416,16 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lit": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
@@ -8342,6 +8511,14 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -8351,6 +8528,14 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
@@ -8393,6 +8578,13 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -8513,6 +8705,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -8574,6 +8773,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/marked": {
@@ -8681,6 +8898,13 @@
         "ssr-window": "^4.0.2",
         "tslib": "^2.6.3"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -9544,6 +9768,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/openapi3-ts": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.2.0.tgz",
@@ -10368,6 +10600,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pupa": {
@@ -12302,6 +12544,108 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
+      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/sync-child-process": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
@@ -12812,6 +13156,56 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.28.15",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.15.tgz",
+      "integrity": "sha512-mw2/2vTL7MlT+BVo43lOsufkkd2CJO4zeOSuWQQsiXoV2VuEn7f6IZp2jsUDPmBMABpgR0R5jlcJ2OGEFYmkyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.17.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
@@ -12852,6 +13246,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",
@@ -13099,6 +13500,16 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.26",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
+      "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/varint": {
@@ -13394,15 +13805,19 @@
       "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
     "node_modules/yaml": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
-      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {
@@ -13449,6 +13864,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/zip-stream": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@rsbuild/plugin-sass": "^1.3.1",
     "@types/cookie-parser": "^1.4.8",
     "@types/cors": "^2.8.19",
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui-express": "^4.1.8",
     "esbuild": "0.25.3",
     "firebase-tools": "14.2.2",
     "gts": "6.0.2",
@@ -51,6 +53,9 @@
     "mdui": "^2.1.3",
     "nodemon": "3.1.10",
     "rimraf": "6.0.1",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1",
+    "typedoc": "^0.28.15",
     "ua-parser-js": "^1.0.40",
     "webauthn-polyfills": "^0.1.7"
   },
@@ -65,7 +70,7 @@
     "clean": "rimraf ./dist",
     "build:client": "npx rsbuild build",
     "build:server": "node esbuild.config.mjs",
-    "build": "npm run clean && npm run build:client && npm run build:server",
+    "build": "npm run clean && npm run build:client && npm run build:server && npm run docs:build",
     "dev:server": "nodemon --watch 'src/server/*' -e ts,html --exec 'node esbuild.config.mjs && PROXY=true node --enable-source-maps dist/server/app.js'",
     "dev:client": "npx rsbuild dev",
     "dev": "npm run dev:client & NODE_ENV=localhost npm run dev:server",
@@ -79,6 +84,8 @@
     "deploy:prod": "CLOUDSDK_CORE_PROJECT=identity-sesame gcloud app deploy prod.yaml",
     "logs": "gcloud app logs tail --project=project-sesame-426206",
     "emulator": "firebase emulators:start --only firestore --project=project-sesame-426206 --import=./.data --export-on-exit",
-    "lint:fix": "eslint -c .eslintrc --fix ./src"
+    "lint:fix": "eslint -c .eslintrc --fix ./src",
+    "docs:build": "typedoc",
+    "docs:serve": "http-server dist/docs"
   }
 }

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -139,12 +139,44 @@ app.locals.origin_trials = config.origin_trials;
 app.locals.repository_url = config.repository_url;
 app.locals.debug = config.debug;
 
+/**
+ * Landing Page.
+ * @swagger
+ * /:
+ *   get:
+ *     summary: Landing Page
+ *     description: Renders the welcome page.
+ *     tags: [Pages]
+ *     responses:
+ *       200:
+ *         description: HTML Page
+ *         content:
+ *           text/html:
+ *             schema:
+ *               type: string
+ */
 app.get('/', pageAclCheck(PageType.NoAuth), (req: Request, res: Response): void => {
   return res.render('index.html', {
     title: 'Welcome!',
   });
 });
 
+/**
+ * Sign-Up Form Page.
+ * @swagger
+ * /signup-form:
+ *   get:
+ *     summary: Sign-Up Form
+ *     description: Renders the sign-up form page.
+ *     tags: [Pages]
+ *     responses:
+ *       200:
+ *         description: HTML Page
+ *         content:
+ *           text/html:
+ *             schema:
+ *               type: string
+ */
 app.get(
   '/signup-form',
   pageAclCheck(PageType.SignUp),
@@ -158,6 +190,22 @@ app.get(
   }
 );
 
+/**
+ * Sign-In Form Page.
+ * @swagger
+ * /signin-form:
+ *   get:
+ *     summary: Sign-In Form
+ *     description: Renders the sign-in form page.
+ *     tags: [Pages]
+ *     responses:
+ *       200:
+ *         description: HTML Page
+ *         content:
+ *           text/html:
+ *             schema:
+ *               type: string
+ */
 app.get(
   '/signin-form',
   pageAclCheck(PageType.SignIn),
@@ -304,6 +352,22 @@ app.get(
   }
 );
 
+/**
+ * Home Page.
+ * @swagger
+ * /home:
+ *   get:
+ *     summary: Home Page
+ *     description: Renders the home page for signed-in users.
+ *     tags: [Pages]
+ *     responses:
+ *       200:
+ *         description: HTML Page
+ *         content:
+ *           text/html:
+ *             schema:
+ *               type: string
+ */
 app.get(
   '/home',
   pageAclCheck(PageType.SignedIn),
@@ -314,6 +378,18 @@ app.get(
   }
 );
 
+/**
+ * Sign Out.
+ * @swagger
+ * /signout:
+ *   get:
+ *     summary: Sign Out
+ *     description: Signs out the user and redirects to the entrance path.
+ *     tags: [Pages]
+ *     responses:
+ *       307:
+ *         description: Redirects to entrance path
+ */
 app.get(
   '/signout',
   pageAclCheck(PageType.SignedIn),
@@ -404,6 +480,18 @@ app.get(
 
 // After successfully registering all routes, add a health check endpoint.
 // Do it last, as previous routes may throw errors during start-up.
+/**
+ * Health Check.
+ * @swagger
+ * /__health-check:
+ *   get:
+ *     summary: Health Check
+ *     description: Returns 200 OK if server is healthy.
+ *     tags: [System]
+ *     responses:
+ *       200:
+ *         description: OK
+ */
 app.get('/__health-check', (req: Request, res: Response): void => {
   res.send('OK');
 });

--- a/src/server/libs/custom-firestore-session.ts
+++ b/src/server/libs/custom-firestore-session.ts
@@ -1,3 +1,20 @@
+/*
+ * @license
+ * Copyright 2025 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
 import {FOREVER, getTime} from '../middlewares/common.ts';
 import {Session, SessionData} from 'express-session';
 import {config} from '../config.ts';

--- a/src/server/middlewares/auth.ts
+++ b/src/server/middlewares/auth.ts
@@ -111,9 +111,30 @@ router.post(
 );
 
 /**
- * Check username, create a new account if it doesn't exist.
- * Set a `username` in the session.
- **/
+ * Check if the username exists and initiate sign-in.
+ * @swagger
+ * /auth/username:
+ *   post:
+ *     summary: Initiate sign-in with username
+ *     description: Checks if a username exists and sets it in the session to begin the sign-in process.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - username
+ *             properties:
+ *               username:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Username accepted
+ *       400:
+ *         description: Invalid username
+ */
 router.post(
   '/username',
   apiAclCheck(ApiType.NoAuth),
@@ -145,6 +166,41 @@ router.post(
 );
 
 // TODO: This part is not really worked on yet
+/**
+ * Create a new user with username and password.
+ * @swagger
+ * /auth/new-username-password:
+ *   post:
+ *     summary: Create user with password
+ *     description: Registers a new user with a username and password.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - username
+ *               - password1
+ *               - password2
+ *             properties:
+ *               username:
+ *                 type: string
+ *               displayName:
+ *                 type: string
+ *               password1:
+ *                 type: string
+ *               password2:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: User created and signed in
+ *       400:
+ *         description: Invalid input or username taken
+ *       401:
+ *         description: Failed to sign in
+ */
 router.post(
   '/new-username-password',
   apiAclCheck(ApiType.NoAuth),
@@ -192,6 +248,31 @@ router.post(
   }
 );
 
+/**
+ * Set a password for a new user during sign-up.
+ * @swagger
+ * /auth/new-password:
+ *   post:
+ *     summary: Set new user password
+ *     description: Sets the password for a user currently in the sign-up process.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - password
+ *             properties:
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Password set and user signed in
+ *       401:
+ *         description: Invalid password or session state
+ */
 router.post(
   '/new-password',
   apiAclCheck(ApiType.SigningUp),
@@ -232,7 +313,29 @@ router.post(
  * Verifies user credential and let the user sign-in.
  * No preceding registration required.
  * This only checks if `username` is not empty string and ignores the password.
- **/
+ * @swagger
+ * /auth/password:
+ *   post:
+ *     summary: Sign in with password
+ *     description: Verifies password for the user in the current session context.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - password
+ *             properties:
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Signed in successfully
+ *       401:
+ *         description: Invalid password or failed to sign in
+ */
 router.post(
   '/password',
   apiAclCheck(ApiType.FirstCredential),
@@ -260,6 +363,34 @@ router.post(
   }
 );
 
+/**
+ * Sign in with username and password.
+ * @swagger
+ * /auth/username-password:
+ *   post:
+ *     summary: Sign in with username and password
+ *     description: Authenticates a user using their username and password.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - username
+ *               - password
+ *             properties:
+ *               username:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Signed in successfully
+ *       401:
+ *         description: Failed to sign in
+ */
 router.post(
   '/username-password',
   apiAclCheck(ApiType.SignIn),
@@ -286,6 +417,36 @@ router.post(
   }
 );
 
+/**
+ * Change the current user's password.
+ * @swagger
+ * /auth/password-change:
+ *   post:
+ *     summary: Change password
+ *     description: Updates the password for the currently signed-in user.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - new-password1
+ *               - new-password2
+ *             properties:
+ *               new-password1:
+ *                 type: string
+ *               new-password2:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Password updated successfully
+ *       400:
+ *         description: Passwords do not match or are invalid
+ *       401:
+ *         description: User not signed in
+ */
 router.post(
   '/password-change',
   apiAclCheck(ApiType.Sensitive),
@@ -313,6 +474,17 @@ router.post(
 
 /**
  * Response with user information.
+ * @swagger
+ * /auth/userinfo:
+ *   post:
+ *     summary: Get user info
+ *     description: Retrieves information about the currently signed-in user.
+ *     tags: [Auth]
+ *     responses:
+ *       200:
+ *         description: User information
+ *       401:
+ *         description: User not signed in
  */
 router.post(
   '/userinfo',
@@ -330,6 +502,30 @@ router.post(
 
 /**
  * Update the user's display name.
+ * @swagger
+ * /auth/updateDisplayName:
+ *   post:
+ *     summary: Update display name
+ *     description: Updates the display name for the currently signed-in user.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - newName
+ *             properties:
+ *               newName:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Profile updated
+ *       400:
+ *         description: Missing new name
+ *       401:
+ *         description: User not signed in
  */
 router.post(
   '/updateDisplayName',
@@ -354,6 +550,20 @@ router.post(
   }
 );
 
+/**
+ * Delete the current user's account.
+ * @swagger
+ * /auth/delete-user:
+ *   post:
+ *     summary: Delete user account
+ *     description: Deletes the currently signed-in user's account. Requires recent authentication.
+ *     tags: [Auth]
+ *     responses:
+ *       200:
+ *         description: Account deleted successfully
+ *       401:
+ *         description: User not signed in or session too old
+ */
 router.post(
   '/delete-user',
   apiAclCheck(ApiType.Sensitive),

--- a/src/server/middlewares/auth.ts
+++ b/src/server/middlewares/auth.ts
@@ -37,6 +37,30 @@ router.use(csrfCheck);
 
 /**
  * Start creating a new user
+ * @swagger
+ * /auth/new-user:
+ *   post:
+ *     summary: Create a new user
+ *     description: Starts the registration process for a new user.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - username
+ *             properties:
+ *               username:
+ *                 type: string
+ *               displayName:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: User created successfully
+ *       400:
+ *         description: Username invalid or taken
  */
 router.post(
   '/new-user',

--- a/src/server/middlewares/fedcm.ts
+++ b/src/server/middlewares/fedcm.ts
@@ -46,6 +46,35 @@ router.use(
   })
 );
 
+/**
+ * Get FedCM configuration.
+ * @swagger
+ * /fedcm/config.json:
+ *   get:
+ *     summary: FedCM Configuration
+ *     description: Returns the FedCM configuration file required for the IDP.
+ *     tags: [FedCM]
+ *     responses:
+ *       200:
+ *         description: Configuration object
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 accounts_endpoint:
+ *                   type: string
+ *                 client_metadata_endpoint:
+ *                   type: string
+ *                 id_assertion_endpoint:
+ *                   type: string
+ *                 disconnect_endpoint:
+ *                   type: string
+ *                 login_url:
+ *                   type: string
+ *                 branding:
+ *                   type: object
+ */
 router.get(
   '/config.json',
   apiAclCheck(ApiType.NoAuth),
@@ -70,6 +99,36 @@ router.get(
   }
 );
 
+/**
+ * Get FedCM accounts.
+ * @swagger
+ * /fedcm/accounts:
+ *   get:
+ *     summary: List Accounts
+ *     description: Returns a list of accounts for FedCM.
+ *     tags: [FedCM]
+ *     responses:
+ *       200:
+ *         description: Accounts list
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 accounts:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                       name:
+ *                         type: string
+ *                       email:
+ *                         type: string
+ *                       picture:
+ *                         type: string
+ * */
 router.get(
   '/accounts',
   fedcmCheck,
@@ -95,6 +154,27 @@ router.get(
   }
 );
 
+/**
+ * Get FedCM client metadata.
+ * @swagger
+ * /fedcm/metadata:
+ *   get:
+ *     summary: Client Metadata
+ *     description: Returns metadata URLs for the IDP, such as privacy policy and terms of service.
+ *     tags: [FedCM]
+ *     responses:
+ *       200:
+ *         description: Metadata URLs
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 privacy_policy_url:
+ *                   type: string
+ *                 terms_of_service_url:
+ *                   type: string
+ */
 router.get(
   '/metadata',
   apiAclCheck(ApiType.NoAuth),
@@ -106,6 +186,41 @@ router.get(
   }
 );
 
+/**
+ * Issue an identity assertion.
+ * @swagger
+ * /fedcm/idtokens:
+ *   post:
+ *     summary: Issue ID Token
+ *     description: Verifies the request and issues an ID token for FedCM.
+ *     tags: [FedCM]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - client_id
+ *               - nonce
+ *               - account_id
+ *             properties:
+ *               client_id:
+ *                 type: string
+ *               nonce:
+ *                 type: string
+ *               account_id:
+ *                 type: string
+ *               consent_acquired:
+ *                 type: string
+ *               disclosure_text_shown:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: ID Token issued
+ *       400:
+ *         description: Bad request or validation failure
+ */
 router.post(
   '/idtokens',
   fedcmCheck,
@@ -206,6 +321,36 @@ router.post(
   }
 );
 
+/**
+ * Disconnect a client.
+ * @swagger
+ * /fedcm/disconnect:
+ *   post:
+ *     summary: Disconnect Client
+ *     description: Revokes the user's approval for a specific client (RP).
+ *     tags: [FedCM]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - client_id
+ *               - account_hint
+ *             properties:
+ *               client_id:
+ *                 type: string
+ *               account_hint:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Disconnected successfully
+ *       400:
+ *         description: Client not connected or bad request
+ *       401:
+ *         description: Account hint mismatch
+ */
 router.post(
   '/disconnect',
   fedcmCheck,

--- a/src/server/middlewares/federation.ts
+++ b/src/server/middlewares/federation.ts
@@ -40,6 +40,33 @@ const googleClient = new OAuth2Client();
 router.use(csrfCheck);
 
 /**
+ * Get Identity Provider options.
+ * @swagger
+ * /federation/options:
+ *   post:
+ *     summary: Get IdP Options
+ *     description: Returns a list of identity providers based on the provided URLs and a challenge nonce.
+ *     tags: [Federation]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - urls
+ *             properties:
+ *               urls:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *     responses:
+ *       200:
+ *         description: IdP options and nonce
+ *       400:
+ *         description: Bad request
+ *       404:
+ *         description: No matching identity provider found
  */
 router.post(
   '/options',
@@ -80,6 +107,23 @@ router.post(
  * the currently signed-in user. It returns an array of federation mapping
  * objects, each containing details about the federated identity and its
  * association with the user.
+ * @swagger
+ * /federation/mappings:
+ *   get:
+ *     summary: Get Federation Mappings
+ *     description: Returns a list of federation mappings for the currently signed-in user.
+ *     tags: [Federation]
+ *     responses:
+ *       200:
+ *         description: List of federation mappings
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *       400:
+ *         description: Error fetching mappings
  * @param req The Express Request object.
  * @param res The Express Response object, used to send the list of federation mappings.
  * @returns A Promise that resolves to the Express Response object containing the list of federation mappings.
@@ -122,6 +166,31 @@ router.get(
  * 10. Responds with the user object upon successful verification and sign-in.
  * 11. Catches any errors during the process and responds with a 401 status
  *     and an error message.
+ * @swagger
+ * /federation/verifyIdToken:
+ *   post:
+ *     summary: Verify ID Token
+ *     description: Verifies an ID token from a federated identity provider and signs the user in.
+ *     tags: [Federation]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - token
+ *               - url
+ *             properties:
+ *               token:
+ *                 type: string
+ *               url:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: User signed in successfully
+ *       401:
+ *         description: ID token verification failed
  * @param req The Express Request object. The body is expected to contain `token` (the raw ID token string)
  *            and `url` (the URL string of the Identity Provider).
  * @param res The Express Response object, used to send the user object or an error.
@@ -222,6 +291,18 @@ router.post(
   }
 );
 
+/**
+ * Verify SD-JWT.
+ * @swagger
+ * /federation/verifySdJwt:
+ *   post:
+ *     summary: Verify SD-JWT
+ *     description: Verifies an SD-JWT (mock implementation).
+ *     tags: [Federation]
+ *     responses:
+ *       200:
+ *         description: Verified successfully
+ */
 router.post(
   '/verifySdJwt',
   apiAclCheck(ApiType.SignIn),
@@ -266,6 +347,21 @@ router.post(
 
 /**
  * Returns a list of IdP URLs based on the environment.
+ * @swagger
+ * /federation/idp-list:
+ *   get:
+ *     summary: List IdPs
+ *     description: Returns a list of available Identity Provider URLs.
+ *     tags: [Federation]
+ *     responses:
+ *       200:
+ *         description: List of IdP URLs
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: string
  */
 router.get(
   '/idp-list',

--- a/src/server/middlewares/settings.ts
+++ b/src/server/middlewares/settings.ts
@@ -28,6 +28,22 @@ router.get('/', (req: Request, res: Response): void => {
   return res.redirect(307, '/home');
 });
 
+/**
+ * Passkey Settings Page.
+ * @swagger
+ * /settings/passkeys:
+ *   get:
+ *     summary: Passkey Settings
+ *     description: Renders the passkey management page.
+ *     tags: [Pages]
+ *     responses:
+ *       200:
+ *         description: HTML Page
+ *         content:
+ *           text/html:
+ *             schema:
+ *               type: string
+ */
 router.get(
   '/passkeys',
   pageAclCheck(PageType.Sensitive),
@@ -38,6 +54,22 @@ router.get(
   }
 );
 
+/**
+ * Password Change Page.
+ * @swagger
+ * /settings/password-change:
+ *   get:
+ *     summary: Password Change
+ *     description: Renders the password change page.
+ *     tags: [Pages]
+ *     responses:
+ *       200:
+ *         description: HTML Page
+ *         content:
+ *           text/html:
+ *             schema:
+ *               type: string
+ */
 router.get(
   '/password-change',
   pageAclCheck(PageType.Sensitive),
@@ -50,6 +82,22 @@ router.get(
   }
 );
 
+/**
+ * Identity Providers Settings Page.
+ * @swagger
+ * /settings/identity-providers:
+ *   get:
+ *     summary: Identity Providers
+ *     description: Renders the identity providers settings page.
+ *     tags: [Pages]
+ *     responses:
+ *       200:
+ *         description: HTML Page
+ *         content:
+ *           text/html:
+ *             schema:
+ *               type: string
+ */
 router.get(
   '/identity-providers',
   pageAclCheck(PageType.SignedIn),
@@ -60,6 +108,22 @@ router.get(
   }
 );
 
+/**
+ * Delete Account Page.
+ * @swagger
+ * /settings/delete-account:
+ *   get:
+ *     summary: Delete Account
+ *     description: Renders the delete account page.
+ *     tags: [Pages]
+ *     responses:
+ *       200:
+ *         description: HTML Page
+ *         content:
+ *           text/html:
+ *             schema:
+ *               type: string
+ */
 router.get(
   '/delete-account',
   pageAclCheck(PageType.Sensitive),

--- a/src/server/middlewares/well-known.ts
+++ b/src/server/middlewares/well-known.ts
@@ -25,6 +25,24 @@ router.use(
   })
 );
 
+/**
+ * Android Asset Links.
+ * @swagger
+ * /.well-known/assetlinks.json:
+ *   get:
+ *     summary: Asset Links
+ *     description: Returns the Digital Asset Links JSON for verifying native app associations.
+ *     tags: [Well-Known]
+ *     responses:
+ *       200:
+ *         description: Asset links JSON
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ */
 router.get('/assetlinks.json', (req: Request, res: Response): void => {
   const assetlinks = [];
   for (const domain of config.associated_domains) {
@@ -56,6 +74,27 @@ router.get('/assetlinks.json', (req: Request, res: Response): void => {
   res.json(assetlinks);
 });
 
+/**
+ * Web Identity (FedCM).
+ * @swagger
+ * /.well-known/web-identity:
+ *   get:
+ *     summary: Web Identity
+ *     description: Returns the URL of the FedCM configuration file.
+ *     tags: [Well-Known]
+ *     responses:
+ *       200:
+ *         description: Web identity configuration
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 provider_urls:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ */
 router.get('/web-identity', (req: Request, res: Response): void => {
   const url = new URL(config.origin);
   url.pathname = '/fedcm/config.json';
@@ -65,6 +104,27 @@ router.get('/web-identity', (req: Request, res: Response): void => {
   });
 });
 
+/**
+ * Passkey Endpoints.
+ * @swagger
+ * /.well-known/passkey-endpoints:
+ *   get:
+ *     summary: Passkey Endpoints
+ *     description: Returns URLs for enrolling and managing passkeys.
+ *     tags: [Well-Known]
+ *     responses:
+ *       200:
+ *         description: Passkey endpoints
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 enroll:
+ *                   type: string
+ *                 manage:
+ *                   type: string
+ */
 router.get('/passkey-endpoints', (req: Request, res: Response): void => {
   const url = new URL(config.origin);
   url.pathname = '/settings/passkeys';
@@ -72,6 +132,18 @@ router.get('/passkey-endpoints', (req: Request, res: Response): void => {
   res.json({ enroll: web_endpoint, manage: web_endpoint });
 });
 
+/**
+ * Change Password URL.
+ * @swagger
+ * /.well-known/change-password:
+ *   get:
+ *     summary: Change Password
+ *     description: Redirects to the change password page.
+ *     tags: [Well-Known]
+ *     responses:
+ *       302:
+ *         description: Redirects to /settings/password-change
+ */
 router.get('/change-password', (req: Request, res: Response): void => {
   res.redirect(302, '/settings/password-change');
 });

--- a/src/server/swagger.ts
+++ b/src/server/swagger.ts
@@ -1,3 +1,20 @@
+/*
+ * @license
+ * Copyright 2025 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
 import swaggerJsdoc from 'swagger-jsdoc';
 import {config} from '~project-sesame/server/config.ts';
 

--- a/src/server/swagger.ts
+++ b/src/server/swagger.ts
@@ -1,0 +1,22 @@
+import swaggerJsdoc from 'swagger-jsdoc';
+import {config} from '~project-sesame/server/config.ts';
+
+const options: swaggerJsdoc.Options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Project Sesame API',
+      version: '1.0.0',
+      description: 'API documentation for Project Sesame authentication and identity services.',
+    },
+    servers: [
+      {
+        url: config.origin,
+        description: 'Current verified origin',
+      },
+    ],
+  },
+  apis: ['./src/server/middlewares/*.ts'], // Path to the API docs
+};
+
+export const swaggerSpec = swaggerJsdoc(options);

--- a/src/server/swagger.ts
+++ b/src/server/swagger.ts
@@ -16,7 +16,7 @@ const options: swaggerJsdoc.Options = {
       },
     ],
   },
-  apis: ['./src/server/middlewares/*.ts'], // Path to the API docs
+  apis: ['./src/server/middlewares/*.ts', './src/server/app.ts'], // Path to the API docs
 };
 
 export const swaggerSpec = swaggerJsdoc(options);

--- a/src/shared/public/fedcm.js
+++ b/src/shared/public/fedcm.js
@@ -1,3 +1,20 @@
+/*
+ * @license
+ * Copyright 2025 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
 /* eslint-disable no-undef */
 
 export class IdentityProvider {

--- a/src/shared/views/docs.html
+++ b/src/shared/views/docs.html
@@ -8,7 +8,7 @@
     <div class="mdui-col-sm-6 mdui-col-md-4">
       <div class="mdui-card">
         <div class="mdui-card-primary">
-          <div class="mdui-card-primary-title">API Reference</div>
+          <div class="mdui-card-primary-title">Endpoint Reference</div>
           <div class="mdui-card-primary-subtitle">Server Endpoints</div>
         </div>
         <div class="mdui-card-content">
@@ -23,7 +23,7 @@
     <div class="mdui-col-sm-6 mdui-col-md-4">
       <div class="mdui-card">
         <div class="mdui-card-primary">
-          <div class="mdui-card-primary-title">Code Reference</div>
+          <div class="mdui-card-primary-title">API Reference</div>
           <div class="mdui-card-primary-subtitle">TypeScript/Frontend</div>
         </div>
         <div class="mdui-card-content">

--- a/src/shared/views/docs.html
+++ b/src/shared/views/docs.html
@@ -1,0 +1,53 @@
+<div class="mdui-container">
+  <div class="mdui-typo">
+    <h1>Project Sesame Documentation</h1>
+    <p>Welcome to the developer documentation for Project Sesame.</p>
+  </div>
+
+  <div class="mdui-row mdui-m-t-4">
+    <div class="mdui-col-sm-6 mdui-col-md-4">
+      <div class="mdui-card">
+        <div class="mdui-card-primary">
+          <div class="mdui-card-primary-title">API Reference</div>
+          <div class="mdui-card-primary-subtitle">Server Endpoints</div>
+        </div>
+        <div class="mdui-card-content">
+          Interactive documentation for server-side endpoints (OpenAPI/Swagger).
+        </div>
+        <div class="mdui-card-actions">
+          <a href="/docs/endpoints" class="mdui-btn mdui-ripple mdui-color-theme-accent">View APIs</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="mdui-col-sm-6 mdui-col-md-4">
+      <div class="mdui-card">
+        <div class="mdui-card-primary">
+          <div class="mdui-card-primary-title">Code Reference</div>
+          <div class="mdui-card-primary-subtitle">TypeScript/Frontend</div>
+        </div>
+        <div class="mdui-card-content">
+          Generated documentation for TypeScript classes, interfaces, and functions.
+        </div>
+        <div class="mdui-card-actions">
+          <a href="/docs/apis" class="mdui-btn mdui-ripple mdui-color-theme-accent">View Code</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="mdui-col-sm-6 mdui-col-md-4">
+      <div class="mdui-card">
+        <div class="mdui-card-primary">
+          <div class="mdui-card-primary-title">Guides</div>
+          <div class="mdui-card-primary-subtitle">Setup & Contributing</div>
+        </div>
+        <div class="mdui-card-content">
+          <div class="mdui-list">
+            <a href="/docs/guides/readme" class="mdui-list-item mdui-ripple">Environment Setup</a>
+            <a href="/docs/guides/contributing" class="mdui-list-item mdui-ripple">Contributing</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/shared/views/layouts/simple.html
+++ b/src/shared/views/layouts/simple.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{title}}</title>
+    <link rel="stylesheet" href="https://unpkg.com/mdui@1.0.2/dist/css/mdui.min.css"/>
+    <style>
+      body { padding: 20px; max-width: 800px; margin: 0 auto; }
+      img { max-width: 100%; }
+    </style>
+  </head>
+  <body class="mdui-typo">
+    {{{body}}}
+  </body>
+</html>

--- a/tsconfig.doc.json
+++ b/tsconfig.doc.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "paths": {
+      "~project-sesame/client/*": ["client/*"],
+      "~project-sesame/server/*": ["server/*"],
+      "~project-sesame/shared/*": ["shared/*"]
+    },
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,15 @@
+{
+  "entryPoints": [
+    "src/client",
+    "src/shared"
+  ],
+  "out": "dist/docs/apis",
+  "name": "Project Sesame Code Reference",
+  "readme": "README.md",
+  "tsconfig": "tsconfig.doc.json",
+  "entryPointStrategy": "expand",
+  "skipErrorChecking": true,
+  "exclude": [
+    "**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
Add swagger and typedoc to auto-generate API and endpoint documents.
This only builds the infrastructure. Some comments are auto-generated along with this pull request, but they are not sufficiently examined. I hope to add more comments to generate meaningful documents in the future.