### PR TITLE
Fix the issue not being able to build on staging environment

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -22,4 +22,3 @@ firebase-export-*
 CONTRIBUTING.md
 *.log
 LICENSE
-README.md

--- a/src/client/helpers/identity.ts
+++ b/src/client/helpers/identity.ts
@@ -18,7 +18,7 @@
 import {$, post} from '~project-sesame/client/helpers/index';
 import {saveFederation} from '~project-sesame/client/helpers/federated';
 
-interface FedCmOptions {
+export interface FedCmOptions {
   mode?: 'active' | 'passive';
   loginHint?: string;
   context?: string;

--- a/src/client/helpers/index.ts
+++ b/src/client/helpers/index.ts
@@ -213,7 +213,7 @@ export async function post(
 /**
  * Dialog controller
  */
-class SesameDialog {
+export class SesameDialog {
   dialog: Dialog;
 
   constructor() {
@@ -242,7 +242,7 @@ export const dialog = new SesameDialog();
 /**
  * Indicate loading status using a material progress web component.
  */
-class Loading {
+export class Loading {
   progress: LinearProgress;
 
   constructor() {

--- a/src/client/helpers/publickey.ts
+++ b/src/client/helpers/publickey.ts
@@ -194,8 +194,6 @@ export async function authenticate(
 
 /**
  * Signal the list of credentials so the password manager can synchronize.
- * @param { object } credentials An array of credentials that contains a
- * Base64URL encoded credential ID.
  * @returns a promise that resolve with undefined.
  */
 export async function getAllCredentials(): Promise<


### PR DESCRIPTION
refactor: Export helper classes and interfaces, refine project documentation configuration, and adjust GCloud ignore rules.

- `.cloudignore` file was ignoring `README.md` on the staging environment, but it is required to build with TypeDoc, so removed it from `.cloudignore`.
- Fixed warnings.