### PR TITLE
Fix users table to enable TTL based account eviction

### DIFF
--- a/.agent/rules/license-headers.md
+++ b/.agent/rules/license-headers.md
@@ -1,0 +1,23 @@
+---
+trigger: always_on
+---
+
+ALWAYS add the Apache 2.0 license header to the top of every new source file (TypeScript, JavaScript, CSS, etc.). Use the following template:
+  ```
+  /*
+   * @license
+   * Copyright 2026 Google Inc. All rights reserved.
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *     https://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License
+   */
+  ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,6 @@ The local setup mimics a real-world scenario using **Caddy** as a reverse proxy:
 
 ### General rules
 
-* Don't forget to add Appache 2.0 license header at the top of the source code.
-
 ### Adding a new sign-in/sign-up page
 
 When a new page is being added, the following steps are required:

--- a/src/server/libs/custom-firestore-session.ts
+++ b/src/server/libs/custom-firestore-session.ts
@@ -15,7 +15,7 @@
  * limitations under the License
  */
 
-import {FOREVER, getTime} from '../middlewares/common.ts';
+import { ALLOW_LISTED_FOREVER, getTime } from '../middlewares/common.ts';
 import {Session, SessionData} from 'express-session';
 import {config} from '../config.ts';
 import {FirestoreStore, StoreOptions} from '@google-cloud/connect-firestore';
@@ -62,7 +62,7 @@ export class CustomFirestoreStore extends FirestoreStore {
     // config.long_session_duration is expected to be in milliseconds.
     let expiresAt: number;
     if (config.allowlisted_accounts.includes(username)) {
-      expiresAt = getTime(FOREVER);
+      expiresAt = getTime(ALLOW_LISTED_FOREVER);
     } else {
       expiresAt = getTime(config.long_session_duration);
     }

--- a/src/server/middlewares/common.ts
+++ b/src/server/middlewares/common.ts
@@ -51,4 +51,4 @@ export function getTime(offset = 0): number {
   return new Date().getTime() + offset;
 }
 
-export const FOREVER: number = 1000 * 60 * 60 * 24 * 400;
+export const ALLOW_LISTED_FOREVER: number = 1000 * 60 * 60 * 24 * 400;


### PR DESCRIPTION
We evict user accounts older than 48 hours, but since `reigsteredAt` and `expiresAt` types in the `User` interface are `number`. Make it Firestore's `Timestamp` type so Cloud Console's TTL feature can detect outdated accounts.

This resolves #49 