### PR TITLE
Use sudo explicitly for caddy commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Project Sesame
 
-Project Sesame is an open-source demo web application built with node.js,
+Project Sesame is an open-source demo web application built with Node.js,
 designed to provide a hands-on environment for web developers to explore,
 experiment and learn a wide range of identity and authentication features and
 patterns.
@@ -35,7 +35,7 @@ patterns.
 npm ci
 ```
 
-### Bulid
+### Build
 
 ```shell
 npm run build
@@ -43,14 +43,17 @@ npm run build
 
 ### Run
 
-This command will run emulator, RP and IdP projects, and Caddy proxy:
+This command will run the emulator, RP and IdP projects, and Caddy proxy:
 
 ```shell
-sudo npm run dev:local
+npm run dev:local
 ```
 
-Caddy should proxy from [https://rp.localhost](https://rp.localhost) to `localhost:8080` and [https://idp.localhost](https://idp.localhost) to `localhost:8000`, 
+Caddy should proxy from https://rp.localhost to `localhost:8080` and https://idp.localhost to `localhost:8000`, 
 or other ports that you specify in the `rp-localhost.config.json` and `idp-localhost.config.json` config files.
+
+> [!NOTE]
+> `sudo` is required to run the Caddy scripts. You may need to enter your password during the command.
 
 ## Adding a new sign-in flow
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ or other ports that you specify in the `rp-localhost.config.json` and `idp-local
 > [!NOTE]
 > `sudo` is required to run the Caddy scripts. You may need to enter your password during the command.
 
+### Useful Chrome flags (optional)
+
+For local testing, you can configure Chrome to ignore warnings and errors related to certificates.
+
+* Launch Chrome with the `--ignore-certificate-errors` command line flag
+* Enable `chrome://flags/#unsafely-treat-insecure-origin-as-secure` and set its contents to:
+```text
+https://localhost,wss://localhost:3000,https://rp.localhost,wss://rp.localhost,wss://rp.localhost:3000,https://idp.localhost
+```
+
 ## Adding a new sign-in flow
 
 You can use this code base to try and experiment with new ideas. To add a new

--- a/caddy.sh
+++ b/caddy.sh
@@ -20,7 +20,7 @@ LOG_FILE="caddy.log"
 
 # --- Startup and Cleanup ---
 echo "Attempting to stop any running Caddy instances..."
-npx caddy stop > /dev/null 2>&1 || sudo killall caddy > /dev/null 2>&1 || true
+sudo ./node_modules/.bin/caddy stop > /dev/null 2>&1 || sudo killall caddy > /dev/null 2>&1 || true
 
 # --- Get Ports ---
 RP_PORT=$(node -p "require('./rp-localhost.config.json').port" | sed 's/\x1b\[[0-9;]*m//g')
@@ -34,7 +34,7 @@ echo "To monitor logs, run: tail -f ${LOG_FILE}"
 # Run Caddy, redirecting all output, and provide a custom failure message.
 # The parentheses group the command and its redirections.
 (
-  RP_PORT=${RP_PORT} IDP_PORT=${IDP_PORT} npx caddy run --config Caddyfile > "${LOG_FILE}" 2>&1
+  sudo -E env RP_PORT=${RP_PORT} IDP_PORT=${IDP_PORT} ./node_modules/.bin/caddy run --config Caddyfile > "${LOG_FILE}" 2>&1
 ) || {
   # This code runs ONLY if the Caddy process exits with a non-zero status (an error).
   echo "Caddy process failed. See ${LOG_FILE} for details." >&2


### PR DESCRIPTION
I have `npm` installed on my default user account via `nvm` and so it's not available globally. This means running `sudo npm run dev:local` fails.

This PR updates `caddy.sh` to just use `sudo` on the caddy commands pointing at the locally installed version.

I'm not sure if this makes sense as a project change, but it does let me run the development environment on my machine.