### PR TITLE
Flatten session object

### DIFF
--- a/src/server/libs/custom-firestore-session.ts
+++ b/src/server/libs/custom-firestore-session.ts
@@ -16,15 +16,12 @@
  */
 
 import { ALLOW_LISTED_FOREVER, getTime } from '../middlewares/common.ts';
-import {Session, SessionData} from 'express-session';
+import {SessionData} from 'express-session';
 import {config} from '../config.ts';
 import {FirestoreStore, StoreOptions} from '@google-cloud/connect-firestore';
 
 /**
- * Override the Firestore `set` function by adding two additional top-level
- * properties for storing a session: `username` and `expiredAt`.
- * This is to make it easier to query sessions by username and to delete
- * expired sessions.
+ * Override the Firestore `set` and `get` functions for storing a session.
  *
  * @param sid - The session ID.
  * @param sess - The session object.
@@ -34,63 +31,62 @@ export class CustomFirestoreStore extends FirestoreStore {
   constructor(storeOption: StoreOptions) {
     super(storeOption);
   }
-  set = async (
+  get = (
     sid: string,
-    sess: SessionData,
-    callback?: ((err?: Error | undefined) => void) | undefined
-  ): Promise<void> => {
-    let sessionString: string;
-    try {
-      sessionString = JSON.stringify(sess);
-    } catch (stringifyErr: any) {
-      if (typeof callback === 'function') {
-        // Pass the error to the callback
-        return callback(
-          stringifyErr instanceof Error
-            ? stringifyErr
-            : new Error(String(stringifyErr))
-        );
-      }
-      // If no callback, rethrow the error so it's not swallowed
-      throw stringifyErr;
-    }
+    callback: (err?: any, session?: SessionData) => void
+  ): void => {
+    this.db
+      .collection(this.kind)
+      .doc(sid)
+      .get()
+      .then((doc) => {
+        if (!doc.exists) {
+          return callback();
+        }
+        return callback(null, doc.data() as SessionData);
+      })
+      .catch((err) => {
+        return callback(err);
+      });
+  };
 
-    // The 'user' property is added to the SessionData via module augmentation in types.d.ts
-    const username: string | null = (sess as Session)?.user?.username || null;
-
+  set = (
+    sid: string,
+    sess: any,
+    callback?: (err?: any) => void
+  ): void => {
     // Correctly calculate the expiration Date object.
     // config.long_session_duration is expected to be in milliseconds.
     let expiresAt: number;
-    if (config.allowlisted_accounts.includes(username)) {
+    if (sess?.user?.username && config.allowlisted_accounts.includes(sess.user.username)) {
       expiresAt = getTime(ALLOW_LISTED_FOREVER);
     } else {
       expiresAt = getTime(config.long_session_duration);
     }
 
-    try {
-      await this.db.collection(this.kind).doc(sid).set(
-        {
-          data: sessionString,
-          expiresAt, // This will now be a proper Date object for Firestore
-          username,
-        },
-        {merge: true}
-      );
-
-      if (typeof callback === 'function') {
-        callback();
-      }
-    } catch (dbErr: any) {
-      if (typeof callback === 'function') {
-        callback(dbErr instanceof Error ? dbErr : new Error(String(dbErr)));
-      } else {
-        // If no callback, log the error. Consider rethrowing if the caller needs to handle it.
-        console.error(
-          `Firestore set operation failed for session ID ${sid}:`,
-          dbErr
-        );
-        // throw dbErr; // Optionally rethrow
-      }
-    }
+    this.db
+      .collection(this.kind)
+      .doc(sid)
+      .set({
+        ...sess,
+        expiresAt,
+      }, {merge: true}
+      )
+      .then(() => {
+        if (typeof callback === 'function') {
+          callback();
+        }
+      })
+      .catch((dbErr) => {
+        if (typeof callback === 'function') {
+          callback(dbErr instanceof Error ? dbErr : new Error(String(dbErr)));
+        } else {
+          // If no callback, log the error. Consider rethrowing if the caller needs to handle it.
+          console.error(
+            `Firestore set operation failed for session ID ${sid}:`,
+            dbErr
+          );
+        }
+      });
   };
 }


### PR DESCRIPTION
Because session objects are saved as a string, querying and deleting session entries are not possible. By flattening session objects, they are now query-able.