### PR TITLE
fix: configuration inheritance and de-duplication in local environments

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -114,6 +114,13 @@ function mergeConfigs(target: any, source: any) {
             map.set(item.origin, item)
           );
           result[key] = Array.from(map.values());
+        } else if (key === 'associated_domains') {
+          const map = new Map();
+          [...target[key], ...source[key]].forEach(item => {
+            const id = item.site || item.package_name;
+            map.set(id, item);
+          });
+          result[key] = Array.from(map.values());
         } else {
           result[key] = [...new Set([...target[key], ...source[key]])];
         }
@@ -132,7 +139,24 @@ function mergeConfigs(target: any, source: any) {
   return result;
 }
 
-const mergedConfig = mergeConfigs(defaultConfig, envConfig);
+let mergedConfig = mergeConfigs({}, defaultConfig);
+
+if (is_mock_cross_site && env !== 'localhost') {
+  const localhostConfigPath = path.join(
+    project_root_file_path,
+    'localhost.config.json'
+  );
+  try {
+    const localhostConfig = (
+      await import(localhostConfigPath, {with: {type: 'json'}})
+    ).default;
+    mergedConfig = mergeConfigs(mergedConfig, localhostConfig);
+  } catch (e) {
+    // Ignore if localhost.config.json is missing
+  }
+}
+
+mergedConfig = mergeConfigs(mergedConfig, envConfig);
 
 const {
   hostname,

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -141,7 +141,7 @@ function mergeConfigs(target: any, source: any) {
 
 let mergedConfig = mergeConfigs({}, defaultConfig);
 
-if (is_mock_cross_site && env !== 'localhost') {
+if (is_mock_cross_site) {
   const localhostConfigPath = path.join(
     project_root_file_path,
     'localhost.config.json'


### PR DESCRIPTION
This PR addresses a bug encountered during local development where the `rp-localhost` and `idp-localhost` environments were not inheriting configurations from the base `localhost.config.json` file. This caused issues, such as the Google IdP being missing when testing FedCM.

### Changes:
- **Configuration Inheritance:** Refactored `src/server/config.ts` to load and merge `localhost.config.json` as an intermediate layer when running in local sub-environments.
- **De-duplication Fix:** Updated the `mergeConfigs` function to correctly de-duplicate `associated_domains` objects using `site` or `package_name`. Previously, `new Set()` was failing to de-duplicate these objects by value.