### PR TITLE
Fix for cookie bar display

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,6 +53,7 @@ export default tseslint.config(
       'sonarjs/hashing': 'off',
       'sonarjs/slow-regex': 'off',
       'sonarjs/assertions-in-tests': 'off', // Node standard assert library is used
+      'sonarjs/constructor-for-side-effects': 'off',
 
       // Unsanitized (relax for dynamic imports)
       'no-unsanitized/method': 'off',

--- a/src/client/helpers/analytics.ts
+++ b/src/client/helpers/analytics.ts
@@ -28,6 +28,8 @@ declare global {
 export function initAnalytics() {
   if (window.self !== window.top) {
     return;
+  } else {
+    new window.glue.CookieNotificationBar();
   }
 
   window.dataLayer = window.dataLayer || [];

--- a/src/client/helpers/analytics.ts
+++ b/src/client/helpers/analytics.ts
@@ -28,7 +28,7 @@ declare global {
 export function initAnalytics() {
   if (window.self !== window.top) {
     return;
-  } else {
+  } else if (window.glue.CookieNotificationBar) {
     new window.glue.CookieNotificationBar();
   }
 

--- a/src/client/helpers/publickey.ts
+++ b/src/client/helpers/publickey.ts
@@ -205,11 +205,16 @@ export async function authenticate(params?: {
   controller.abort();
   controller = new AbortController();
 
-  const options = await preparePublicKeyRequestOptions(params?.mediation);
-  options.extensions = {};
-  // @ts-ignore
-  options.extensions['crossDeviceFallbackUrl'] =
-    'https://rp.localhost/passkey-form-autofill';
+  let options;
+
+  try {
+    options = await preparePublicKeyRequestOptions(params?.mediation);
+  } catch (e: any) {
+    if (e.status === 404) {
+      throw new DOMException(e.error, 'NotAllowedError');
+    }
+    throw new Error(e.error);
+  }
 
   // Invoke WebAuthn get
   const cred = (await navigator.credentials.get({

--- a/src/shared/views/partials/head.html
+++ b/src/shared/views/partials/head.html
@@ -54,4 +54,5 @@
 <script
   src="https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.js"
   data-glue-cookie-notification-bar-category="2A"
+  data-glue-cookie-notification-bar-autoload="false"
 ></script>


### PR DESCRIPTION
The previous change didn't fix the issue the cookie bar being displayed with iframek, because it's displayed as soon as the script is loaded.

With this change, autoloading the cookie bar is disabled and only enabled when the window is the top frame.