### PR TITLE
refactor: remove Google IdP and modernize FedCM active/passive mode guides

### DIFF
--- a/localhost.config.json
+++ b/localhost.config.json
@@ -7,15 +7,5 @@
     "connect_src": ["wss://localhost:3000", "wss://localhost:3001"]
   },
   "primary_idp_origin": "https://sesame-identity-provider.appspot.com",
-  "supported_idps": [
-    {
-      "name": "Google",
-      "iconURL": "https://accounts.google.com/gsi-static/google-logo.png",
-      "origin": "https://accounts.google.com",
-      "configURL": "https://accounts.google.com/gsi/fedcm.json",
-      "clientId": "493201854729-bposa1duevdn4nspp28cmn6anucu60pf.apps.googleusercontent.com",
-      "secret": "*****"
-    }
-  ],
   "analytics_id": "G-V64M3LXRDX"
 }

--- a/prod.config.json
+++ b/prod.config.json
@@ -30,21 +30,6 @@
       "origin": "https://sesame-identity-provider.appspot.com",
       "configURL": "https://sesame-identity-provider.appspot.com/fedcm/config.json",
       "secret": "xxxxx"
-    },
-    {
-      "name": "Google",
-      "iconURL": "https://accounts.google.com/gsi-static/google-logo.png",
-      "origin": "https://accounts.google.com",
-      "configURL": "https://accounts.google.com/gsi/fedcm.json",
-      "clientId": "493201854729-bposa1duevdn4nspp28cmn6anucu60pf.apps.googleusercontent.com",
-      "secret": "*****"
-    },
-    {
-      "name": "Google Sandbox",
-      "iconURL": "https://accounts.google.com/gsi-static/google-logo.png",
-      "origin": "https://accounts.sandbox.google.com",
-      "configURL": "https://accounts.sandbox.google.com/gsi/vc.json",
-      "secret": "*****"
     }
   ],
   "enabled_pages": [

--- a/rp-localhost.config.json
+++ b/rp-localhost.config.json
@@ -24,14 +24,6 @@
   "primary_idp_origin": "https://idp.localhost",
   "supported_idps": [
     {
-      "name": "Google",
-      "iconURL": "https://accounts.google.com/gsi-static/google-logo.png",
-      "origin": "https://accounts.google.com",
-      "configURL": "https://accounts.google.com/gsi/fedcm.json",
-      "clientId": "493201854729-bposa1duevdn4nspp28cmn6anucu60pf.apps.googleusercontent.com",
-      "secret": "*****"
-    },
-    {
       "name": "FedCM Local IdP",
       "iconURL": "https://idp.localhost/images/idp-logo-512.png",
       "origin": "https://idp.localhost",

--- a/src/client/helpers/identity.test.ts
+++ b/src/client/helpers/identity.test.ts
@@ -1,0 +1,534 @@
+/*
+ * @license
+ * Copyright 2026 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {SesameIdP} from './identity.js';
+import {post, $} from '~project-sesame/client/helpers/index';
+
+// Mock the helpers
+vi.mock('~project-sesame/client/helpers/index', () => ({
+  post: vi.fn(),
+  $: vi.fn(),
+}));
+
+describe('SesameIdP', () => {
+  const mockGet = vi.fn();
+  const mockPreventSilentAccess = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock navigator.credentials
+    vi.stubGlobal('navigator', {
+      credentials: {
+        get: mockGet,
+        preventSilentAccess: mockPreventSilentAccess,
+      },
+    });
+
+    // Mock window and document
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+
+    vi.stubGlobal('document', {
+      querySelector: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('constructor', () => {
+    it('should initialize with URLs', () => {
+      const idp = new SesameIdP([
+        'https://idp.example.com',
+        'https://idp2.example.com/path',
+      ]);
+      expect(idp.urls).toEqual([
+        'https://idp.example.com/',
+        'https://idp2.example.com/path',
+      ]);
+    });
+
+    it('should handle empty URLs', () => {
+      const idp = new SesameIdP([]);
+      expect(idp.urls).toEqual([]);
+    });
+  });
+
+  describe('initialize', () => {
+    it('should initialize and populate idps', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+
+      vi.mocked(post).mockResolvedValueOnce({
+        idps: [
+          {
+            configURL: 'https://idp.example.com/fedcm.json',
+            clientId: 'client123',
+          },
+        ],
+      });
+
+      await idp.initialize();
+
+      expect(post).toHaveBeenCalledWith('/federation/options', {
+        urls: ['https://idp.example.com/'],
+      });
+      expect(idp.idps).toEqual([
+        {
+          origin: 'https://idp.example.com',
+          configURL: 'https://idp.example.com/fedcm.json',
+          clientId: 'client123',
+        },
+      ]);
+    });
+
+    it('should throw error during initialize if configURL is missing', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+
+      vi.mocked(post).mockResolvedValueOnce({
+        idps: [
+          {
+            configURL: '',
+            clientId: 'client123',
+          },
+        ],
+      });
+
+      await expect(idp.initialize()).rejects.toThrow(
+        'configURL or client ID is not declared.'
+      );
+    });
+
+    it('should throw error during initialize if clientId is missing', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+
+      vi.mocked(post).mockResolvedValueOnce({
+        idps: [
+          {
+            configURL: 'https://idp.example.com/fedcm.json',
+            clientId: '',
+          },
+        ],
+      });
+
+      await expect(idp.initialize()).rejects.toThrow(
+        'configURL or client ID is not declared.'
+      );
+    });
+  });
+
+  describe('signIn', () => {
+    it('should perform signIn successfully', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+      idp.idps = [
+        {
+          origin: 'https://idp.example.com',
+          configURL: 'https://idp.example.com/fedcm.json',
+          clientId: 'client123',
+        },
+      ];
+
+      vi.mocked($).mockReturnValue({content: 'mock-nonce'} as any);
+
+      const mockCredential = {
+        configURL: 'https://idp.example.com/fedcm.json',
+        token: 'mock-token',
+      };
+      mockGet.mockResolvedValueOnce(mockCredential);
+
+      const mockUser = {id: 'user123', username: 'testuser'};
+      vi.mocked(post).mockResolvedValueOnce(mockUser);
+
+      const result = await idp.signIn({
+        mode: 'active',
+        loginHint: 'hint',
+        context: 'signin',
+        mediation: 'optional',
+      });
+
+      expect($).toHaveBeenCalledWith('meta[name="nonce"]');
+      expect(mockGet).toHaveBeenCalledWith({
+        identity: {
+          providers: [
+            {
+              configURL: 'https://idp.example.com/fedcm.json',
+              clientId: 'client123',
+              loginHint: 'hint',
+              fields: undefined,
+              params: {nonce: 'mock-nonce'},
+            },
+          ],
+          mode: 'active',
+          context: 'signin',
+        },
+        mediation: 'optional',
+      });
+      expect(post).toHaveBeenCalledWith('/federation/verifyIdToken', {
+        token: 'mock-token',
+        url: 'https://idp.example.com',
+      });
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should throw error if nonce is missing', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+      vi.mocked($).mockReturnValue(null);
+
+      await expect(idp.signIn()).rejects.toThrow('nonce is not declared.');
+    });
+
+    it('should throw error if no verified IdP matches the credential configURL', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+      idp.idps = [
+        {
+          origin: 'https://idp.example.com',
+          configURL: 'https://idp.example.com/fedcm.json',
+          clientId: 'client123',
+        },
+      ];
+
+      vi.mocked($).mockReturnValue({content: 'mock-nonce'} as any);
+
+      const mockCredential = {
+        configURL: 'https://different.com/fedcm.json',
+        token: 'mock-token',
+      };
+      mockGet.mockResolvedValueOnce(mockCredential);
+
+      await expect(idp.signIn()).rejects.toThrow('No verified IdP found.');
+    });
+
+    it('should throw error if backend verification fails', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+      idp.idps = [
+        {
+          origin: 'https://idp.example.com',
+          configURL: 'https://idp.example.com/fedcm.json',
+          clientId: 'client123',
+        },
+      ];
+
+      vi.mocked($).mockReturnValue({content: 'mock-nonce'} as any);
+
+      const mockCredential = {
+        configURL: 'https://idp.example.com/fedcm.json',
+        token: 'mock-token',
+      };
+      mockGet.mockResolvedValueOnce(mockCredential);
+
+      vi.mocked(post).mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(idp.signIn()).rejects.toThrow(
+        'Identity verification failed.'
+      );
+    });
+  });
+
+  describe('delegate', () => {
+    it('should perform delegate successfully', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+      idp.idps = [
+        {
+          origin: 'https://idp.example.com',
+          configURL: 'https://idp.example.com/fedcm.json',
+          clientId: 'client123',
+        },
+      ];
+
+      vi.mocked($).mockReturnValue({content: 'mock-nonce'} as any);
+
+      const mockCredential = {
+        configURL: 'https://idp.example.com/fedcm.json',
+        token: 'mock-vc-token',
+      };
+      mockGet.mockResolvedValueOnce(mockCredential);
+
+      const mockUser = {id: 'user123', username: 'testuser'};
+      vi.mocked(post).mockResolvedValueOnce(mockUser);
+
+      const result = await idp.delegate({
+        fields: ['name', 'email'],
+      });
+
+      expect(mockGet).toHaveBeenCalledWith({
+        identity: {
+          providers: [
+            {
+              format: 'vc+sd-jwt',
+              configURL: 'https://idp.example.com/fedcm.json',
+              clientId: 'client123',
+              fields: ['name', 'email'],
+              params: {nonce: 'mock-nonce'},
+            },
+          ],
+        },
+        mediation: undefined,
+      });
+      expect(post).toHaveBeenCalledWith('/federation/verifySdJwt', {
+        token: 'mock-vc-token',
+        url: 'https://idp.example.com',
+      });
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should throw error if nonce is missing in delegate', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+      vi.mocked($).mockReturnValue(null);
+
+      await expect(idp.delegate()).rejects.toThrow('nonce is not declared.');
+    });
+
+    it('should throw error if no verified IdP matches in delegate', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+      idp.idps = [
+        {
+          origin: 'https://idp.example.com',
+          configURL: 'https://idp.example.com/fedcm.json',
+          clientId: 'client123',
+        },
+      ];
+
+      vi.mocked($).mockReturnValue({content: 'mock-nonce'} as any);
+
+      const mockCredential = {
+        configURL: 'https://different.com/fedcm.json',
+        token: 'mock-token',
+      };
+      mockGet.mockResolvedValueOnce(mockCredential);
+
+      await expect(idp.delegate()).rejects.toThrow('No verified IdP found.');
+    });
+  });
+
+  describe('iframe', () => {
+    it('should resolve iframe promise when receiving valid message', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+      idp.idps = [
+        {
+          origin: 'https://idp.example.com',
+          configURL: 'https://idp.example.com/fedcm.json',
+          clientId: 'client123',
+        },
+      ];
+
+      vi.mocked($).mockReturnValue({content: 'mock-nonce'} as any);
+
+      let messageCallback: ((event: any) => void) | undefined;
+      global.window.addEventListener = vi
+        .fn()
+        .mockImplementation((event, callback) => {
+          if (event === 'message') {
+            messageCallback = callback;
+          }
+        });
+
+      vi.mocked(post).mockResolvedValueOnce(true);
+
+      const iframePromise = idp.iframe();
+
+      expect(global.window.addEventListener).toHaveBeenCalledWith(
+        'message',
+        expect.any(Function)
+      );
+
+      if (messageCallback) {
+        const mockEvent = {
+          origin: 'https://idp.example.com',
+          data: {token: 'iframe-token'},
+          stopPropagation: vi.fn(),
+        };
+        await messageCallback(mockEvent);
+      }
+
+      await expect(iframePromise).resolves.toBeUndefined();
+      expect(post).toHaveBeenCalledWith('/federation/verifyIdToken', {
+        token: 'iframe-token',
+        url: 'https://idp.example.com',
+      });
+      expect(global.window.removeEventListener).toHaveBeenCalledWith(
+        'message',
+        expect.any(Function)
+      );
+    });
+
+    it('should throw error if nonce is missing in iframe', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+      vi.mocked($).mockReturnValue(null);
+
+      const iframePromise = idp.iframe();
+      await expect(iframePromise).rejects.toThrow('nonce is not declared.');
+    });
+
+    it('should throw error if no IdP specified in iframe', async () => {
+      const idp = new SesameIdP(); // No URLs, no idps
+      vi.mocked($).mockReturnValue({content: 'mock-nonce'} as any);
+
+      const iframePromise = idp.iframe();
+      await expect(iframePromise).rejects.toThrow('IdP not specified.');
+    });
+
+    it('should reject iframe promise when token verification fails', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+      idp.idps = [
+        {
+          origin: 'https://idp.example.com',
+          configURL: 'https://idp.example.com/fedcm.json',
+          clientId: 'client123',
+        },
+      ];
+
+      vi.mocked($).mockReturnValue({content: 'mock-nonce'} as any);
+
+      let messageCallback: ((event: any) => void) | undefined;
+      global.window.addEventListener = vi
+        .fn()
+        .mockImplementation((event, callback) => {
+          if (event === 'message') {
+            messageCallback = callback;
+          }
+        });
+
+      vi.mocked(post).mockResolvedValueOnce(false); // verification returns falsy
+
+      const iframePromise = idp.iframe();
+
+      if (messageCallback) {
+        const mockEvent = {
+          origin: 'https://idp.example.com',
+          data: {token: 'iframe-token'},
+          stopPropagation: vi.fn(),
+        };
+        await messageCallback(mockEvent);
+      }
+
+      await expect(iframePromise).rejects.toThrow('Token verification failed.');
+      expect(global.window.removeEventListener).toHaveBeenCalledWith(
+        'message',
+        expect.any(Function)
+      );
+    });
+
+    it('should reject iframe promise when post throws an error', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+      idp.idps = [
+        {
+          origin: 'https://idp.example.com',
+          configURL: 'https://idp.example.com/fedcm.json',
+          clientId: 'client123',
+        },
+      ];
+
+      vi.mocked($).mockReturnValue({content: 'mock-nonce'} as any);
+
+      let messageCallback: ((event: any) => void) | undefined;
+      global.window.addEventListener = vi
+        .fn()
+        .mockImplementation((event, callback) => {
+          if (event === 'message') {
+            messageCallback = callback;
+          }
+        });
+
+      vi.mocked(post).mockRejectedValueOnce({error: 'Server Error'});
+
+      const iframePromise = idp.iframe();
+
+      if (messageCallback) {
+        const mockEvent = {
+          origin: 'https://idp.example.com',
+          data: {token: 'iframe-token'},
+          stopPropagation: vi.fn(),
+        };
+        await messageCallback(mockEvent);
+      }
+
+      await expect(iframePromise).rejects.toThrow('Server Error');
+      expect(global.window.removeEventListener).toHaveBeenCalledWith(
+        'message',
+        expect.any(Function)
+      );
+    });
+
+    it('should ignore messages from different origins', async () => {
+      const idp = new SesameIdP(['https://idp.example.com']);
+      idp.idps = [
+        {
+          origin: 'https://idp.example.com',
+          configURL: 'https://idp.example.com/fedcm.json',
+          clientId: 'client123',
+        },
+      ];
+
+      vi.mocked($).mockReturnValue({content: 'mock-nonce'} as any);
+
+      let messageCallback: ((event: any) => void) | undefined;
+      global.window.addEventListener = vi
+        .fn()
+        .mockImplementation((event, callback) => {
+          if (event === 'message') {
+            messageCallback = callback;
+          }
+        });
+
+      const iframePromise = idp.iframe();
+
+      if (messageCallback) {
+        const mockEvent = {
+          origin: 'https://attacker.com',
+          data: {token: 'attacker-token'},
+          stopPropagation: vi.fn(),
+        };
+        await messageCallback(mockEvent);
+      }
+
+      // The promise should still be pending because the message was ignored.
+      // We can verify that post was not called.
+      expect(post).not.toHaveBeenCalled();
+
+      // Resolve the promise to clean up and avoid lint error
+      vi.mocked(post).mockResolvedValueOnce(true);
+      if (messageCallback) {
+        const mockEvent = {
+          origin: 'https://idp.example.com',
+          data: {token: 'iframe-token'},
+          stopPropagation: vi.fn(),
+        };
+        await messageCallback(mockEvent);
+      }
+      await iframePromise;
+    });
+  });
+
+  describe('signOut', () => {
+    it('should call preventSilentAccess on signOut', async () => {
+      const idp = new SesameIdP();
+      await idp.signOut();
+      expect(mockPreventSilentAccess).toHaveBeenCalled();
+    });
+
+    it('should not throw if preventSilentAccess is not supported', async () => {
+      // @ts-ignore
+      delete global.navigator.credentials.preventSilentAccess;
+      const idp = new SesameIdP();
+      await expect(idp.signOut()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/client/helpers/identity.ts
+++ b/src/client/helpers/identity.ts
@@ -120,27 +120,22 @@ export class SesameIdP {
       });
     }
 
-    try {
-      const cred = await navigator.credentials.get({
-        // @ts-ignore
-        identity: {providers, mode, context},
-        mediation,
-      });
+    const cred = await navigator.credentials.get({
+      // @ts-ignore
+      identity: {providers, mode, context},
+      mediation,
+    });
 
-      /**
-       * IdentityCredential {
-       *   configURL: string,
-       *   id: string,
-       *   isAutoSelected: boolean,
-       *   token: string,
-       *   type: 'identity'
-       * }
-       */
-      return this.verifyIdToken(cred);
-    } catch (e: any) {
-      console.error(e);
-      throw new Error(e.error);
-    }
+    /**
+     * IdentityCredential {
+     *   configURL: string,
+     *   id: string,
+     *   isAutoSelected: boolean,
+     *   token: string,
+     *   type: 'identity'
+     * }
+     */
+    return this.verifyIdToken(cred);
   }
 
   /**
@@ -237,11 +232,16 @@ export class SesameIdP {
       throw new Error('No verified IdP found.');
     }
 
-    // TODO: Make sure the response is User type
-    const user = await post('/federation/verifyIdToken', {
-      token: cred.token,
-      url: idp.origin,
-    });
+    let user;
+    try {
+      // TODO: Make sure the response is User type
+      user = await post('/federation/verifyIdToken', {
+        token: cred.token,
+        url: idp.origin,
+      });
+    } catch (e: any) {
+      throw new Error('Identity verification failed.');
+    }
     return user;
   }
 

--- a/src/client/pages/fedcm-active-mode.ts
+++ b/src/client/pages/fedcm-active-mode.ts
@@ -18,38 +18,22 @@
 import '~project-sesame/client/layout';
 import {$, toast, redirect} from '~project-sesame/client/helpers/index';
 import {SesameIdP} from '~project-sesame/client/helpers/identity';
-
-let fedcm;
-if (location.host.indexOf('rp.localhost') > -1) {
-  fedcm = new SesameIdP(['https://idp.localhost']);
-} else {
-  fedcm = new SesameIdP(['https://identity-provider-sesame.appspot.com']);
-}
-await fedcm.initialize();
-const google = new SesameIdP(['https://accounts.google.com']);
-await google.initialize();
-
-const signIn = async (idp: SesameIdP) => {
-  try {
-    await idp.signIn({mode: 'active'});
-    await redirect('/home');
-  } catch (e: any) {
-    console.error(e);
-    toast(e.message);
-  }
-};
+import {getIdpUrls} from '../helpers/federated';
 
 if ('IdentityCredential' in window) {
   $('#hidden').classList.remove('hidden');
   $('#unsupported').classList.add('hidden');
-
-  $('#google').addEventListener('click', async (event: MouseEvent) => {
-    event.preventDefault();
-    await signIn(google);
-  });
-
+  const idpURLs = await getIdpUrls();
+  const idp = new SesameIdP(idpURLs);
+  await idp.initialize();
   $('#fedcm').addEventListener('click', async (event: MouseEvent) => {
     event.preventDefault();
-    await signIn(fedcm);
+    try {
+      await idp.signIn({mode: 'active'});
+      await redirect('/home');
+    } catch (e: any) {
+      console.error(e);
+      toast(e.message);
+    }
   });
 }

--- a/src/shared/helps/fedcm-active-mode.dev.md
+++ b/src/shared/helps/fedcm-active-mode.dev.md
@@ -14,9 +14,41 @@
  limitations under the License
 -->
 
-## How to integrate FedCM active mode
+## Integrating FedCM active mode
 
-Use `mode: "active"` to indicate that a FedCM invocation should be initiated by
-user interaction. Learn more:
+To implement a user-initiated federated sign-in flow, you can use FedCM's
+**active mode**. This mode is designed for scenarios where the authentication
+request is triggered by an explicit user gesture, such as clicking a "Sign-in"
+button.
 
-- [Implement an identity solution with FedCM on the Relying Party side](https://privacysandbox.google.com/cookies/fedcm/implement/relying-party)
+### Implementation Guide
+
+In active mode, you call `navigator.credentials.get()` and specify `mode:
+'active'` within the `identity` options. Because active mode requires user
+intent, this call must be executed within a user gesture handler (e.g., a button
+click event listener).
+
+### Best practices checklist
+
+When implementing FedCM active mode, follow the best practices:
+
+- **Graceful degradation:** Always implement a fallback mechanism (such as
+  showing standard sign-in buttons) in case the browser does not support
+  `IdentityCredential` or the passive request is rejected.
+- **User gesture requirement:** Ensure that `navigator.credentials.get()` with
+  `mode: 'active'` is invoked directly inside a user interaction handler (like a
+  `click` event). If called without a user gesture, the browser will reject the
+  request.
+- **Credential verification:** Ensure the returned credential is sent to the
+  backend and verified. Note that as FedCM is protocol agnostic, follow the
+  IdP's instructions on how to verify the credential. If it is built on OpenID
+  Connect, the credential is typically an ID token that can be verified against
+  the IdP's public key.
+- **Provide clear entry points:** Clearly label button UI (e.g., "Sign-in with
+  _IdP_") so the user understands that clicking the button will initiate a
+  federated login flow.
+
+### Developer Resources
+
+- **Guide:** [Implement an identity solution with FedCM on the Relying Party side](https://developer.chrome.com/docs/identity/fedcm/implement/relying-party) (Chrome Developer)
+- **Guide:** [Implement an identity solution with FedCM on the Identity Provider side](https://developer.chrome.com/docs/identity/fedcm/implement/identity-provider) (Chrome Developer)

--- a/src/shared/helps/fedcm-active-mode.dev.md
+++ b/src/shared/helps/fedcm-active-mode.dev.md
@@ -14,7 +14,7 @@
  limitations under the License
 -->
 
-## Integrating FedCM active mode
+## Integrate FedCM active mode
 
 To implement a user-initiated federated sign-in flow, you can use FedCM's
 **active mode**. This mode is designed for scenarios where the authentication

--- a/src/shared/helps/fedcm-active-mode.usage.md
+++ b/src/shared/helps/fedcm-active-mode.usage.md
@@ -16,18 +16,25 @@
 
 ## FedCM active mode
 
-In this page, you can experience and learn FedCM active mode.
+On this page, you can experience FedCM's **active mode**.
 
-FedCM has two modes: "passive" and "active".
+### Active vs. passive Mode
 
-- "active": FedCM prompt must be initiated by user interaction (such as clicking a button).
-- "passive": FedCM prompt will be initiated without direct user interaction.
+The Federated Credential Management (FedCM) API supports two distinct UX modes:
 
-## Prerequisites
+- **Active Mode**: The FedCM prompt is triggered by a direct user interaction,
+  such as clicking a "Sign-in" button.
+- **Passive Mode**: The FedCM prompt is initiated automatically when the page
+  loads, without requiring any prior user interaction.
 
-- Google Chrome
+### How to test it:
 
-Last updated: 2025/05/18
-
-Click on **Sign-in with Google** button or **Sign-in with FedCM Demo IdP**
-button. Follow the instructions and sign in.
+1. **Browser Prerequisite:** Ensure you are using a Chromium-based browser that
+   supports FedCM.
+2. **Trigger the flow:** Click the **Sign-in with FedCM Demo IdP** button.
+3. **Complete the sign-in:** A browser-native FedCM dialog will appear. Follow
+   the prompts to select your account and complete the sign-in flow.
+4. **Sign in to the IdP:** If you are not signed in to the IdP yet, a popup
+   window will appear so you can sign in to [the
+   IdP](https://sesame-identity-provider.appspot.com). As soon as you are signed
+   in, you'll be able to sign in to the RP.

--- a/src/shared/helps/fedcm-passive-mode.dev.md
+++ b/src/shared/helps/fedcm-passive-mode.dev.md
@@ -14,9 +14,33 @@
  limitations under the License
 -->
 
-## How to integrate FedCM passive mode
+## Integrating FedCM passive mode
 
-Learn how to implement FedCM on a relying party:
+To create a frictionless federated authentication flow, you can use FedCM's
+**passive mode** to trigger the identity provider (IdP) prompt automatically
+upon page load without requiring a direct user gesture.
 
-- [Implement an identity solution with FedCM on the Relying Party
-  side](https://privacysandbox.google.com/cookies/fedcm/implement/relying-party)
+### Implementation Guide
+
+In passive mode, you call `navigator.credentials.get()` and specify `mode:
+'passive'` within the `identity` options.
+
+### Best practices checklist
+
+When implementing FedCM passive mode, follow the best practices:
+
+- **Graceful degradation:** Always implement a fallback mechanism (such as
+  showing standard sign-in buttons) in case the browser does not support
+  `IdentityCredential` or the passive request is rejected.
+- **Credential verification:** Ensure the returned credential is sent to the
+  backend and verified. Note that as FedCM is protocol agnostic, follow IdP's
+  instructions how to verify the credential. If it's built based on OpenID
+  Connect, the credential is typically and ID token so that you can verify
+  against IdP's public key.
+- **Mediation Control:** Use `mediation` option (such as `'required'` or
+  `'optional'`) to balance user convenience and user control.
+
+### Developer Resources
+
+- **Guide:** [Implement an identity solution with FedCM on the Relying Party side](https://developer.chrome.com/docs/identity/fedcm/implement/relying-party) (Chrome Developer)
+- **Guide:** [Implement an identity solution with FedCM on the Identity Provider side](https://developer.chrome.com/docs/identity/fedcm/implement/identity-provider) (Chrome Developer)

--- a/src/shared/helps/fedcm-passive-mode.dev.md
+++ b/src/shared/helps/fedcm-passive-mode.dev.md
@@ -14,7 +14,7 @@
  limitations under the License
 -->
 
-## Integrating FedCM passive mode
+## Integrate FedCM passive mode
 
 To create a frictionless federated authentication flow, you can use FedCM's
 **passive mode** to trigger the identity provider (IdP) prompt automatically

--- a/src/shared/helps/fedcm-passive-mode.usage.md
+++ b/src/shared/helps/fedcm-passive-mode.usage.md
@@ -16,24 +16,25 @@
 
 ## FedCM passive mode
 
-In this page, you can experience and learn FedCM passive mode.
+On this page, you can experience FedCM's **passive mode**.
 
-FedCM has two modes: "passive" and "active".
+### Passive vs. active mode
 
-- "active": FedCM prompt must be initiated by user interaction (such as clicking a button).
-- "passive": FedCM prompt will be initiated without direct user interaction.
+The Federated Credential Management (FedCM) API supports two distinct UX modes:
 
-## Prerequisites
+- **Active Mode**: The FedCM prompt is triggered by a direct user interaction,
+  such as clicking a "Sign-in" button.
+- **Passive Mode**: The FedCM prompt is initiated automatically when the page
+  loads, without requiring any prior user interaction.
 
-- Google Chrome
+### How to test it:
 
-Last updated: 2025/05/18
-
-If the browser supports FedCM, a FedCM widget will appear at the top right
-corner as soon as you land this page. FedCM on this website supports "[FedCM
-Demo IdP](https://sesame-identity-provider.appspot.com)" and
-"[Google](https://accounts.google.com)".
-
-Select one of identity providers (IdP) and a popup window appears if you haven't
-signed in to the IdP yet. As soon as you are signed in to the IdP, you're signed
-in to this website.
+1. **Browser prerequisite:** Ensure you are using a Chromium-based browser that
+   supports FedCM.
+2. **Observe the prompt**: If your browser supports FedCM, a sign-in dialog
+   should appear in the top-right corner as soon as you land on this page. If
+   not, create an account and sign in to the demo identity provider at
+   [https://sesame-identity-provider.appspot.com](https://sesame-identity-provider.appspot.com)
+   , then come back here.
+3. **Click the dialog**: Clicking on the one tap dialog allows you to sign in to
+   this demo website.

--- a/src/shared/helps/passkey-form-autofill.usage.md
+++ b/src/shared/helps/passkey-form-autofill.usage.md
@@ -14,7 +14,7 @@
  limitations under the License
 -->
 
-## Passkey Form Autofill
+## Passkey form autofill
 
 On this page, you can experience a sign-in flow that seamlessly accommodates
 both passkeys and passwords in a single form—a feature known as "passkey form

--- a/src/shared/views/fedcm-active-mode.html
+++ b/src/shared/views/fedcm-active-mode.html
@@ -2,9 +2,6 @@
   <h2>Use your federated identity to sign in</h2>
   <section class="center">
     <div id="hidden" class="hidden center">
-      <mdui-button id="google" icon="lock--outlined" variant="filled">
-        Sign-in with Google
-      </mdui-button>
       <mdui-button id="fedcm" icon="lock--outlined" variant="filled">
         Sign-in with FedCM Demo IdP
       </mdui-button>

--- a/staging.config.json
+++ b/staging.config.json
@@ -47,8 +47,8 @@
     {
       "name": "Google",
       "iconURL": "https://accounts.google.com/gsi-static/google-logo.png",
-      "origin": "https://accounts.sandbox.google.com",
-      "configURL": "https://accounts.sandbox.google.com/gsi/vc.json",
+      "origin": "https://accounts.google.com",
+      "configURL": "https://accounts.google.com/gsi/fedcm.json",
       "secret": "*****"
     },
     {


### PR DESCRIPTION
#### Overview
This PR streamlines the federated sign-in experience by removing Google as a supported Identity Provider (IdP) from the local, production, and relying party configurations, simplifying the active mode UI/client-side logic, and fully modernizing the corresponding developer and user help documentation.

---

#### Key Changes

##### 1. Code Changes & Configuration Updates
* **Removed Google IdP Configuration**:
  * Cleaned up `localhost.config.json`, `prod.config.json`, and `rp-localhost.config.json` to remove Google from the list of `supported_idps`.
  * Updated Google's origin and configuration URL in `staging.config.json`.
* **Simplified Active Mode UI & Client Script (`fedcm-active-mode.html` & `fedcm-active-mode.ts`)**:
  * Removed the **Sign-in with Google** button from the page view.
  * Refactored the client-side script to fetch IdP URLs dynamically via `getIdpUrls()`, initialize the `SesameIdP` instance, and handle only the remaining **Sign-in with FedCM Demo IdP** click event.
* **Refactored Identity Helper (`src/client/helpers/identity.ts`)**:
  * Streamlined the credential retrieval process by removing the outer `try-catch` wrapper around `navigator.credentials.get()`.
  * Wrapped the `/federation/verifyIdToken` post request in a distinct `try-catch` block to handle token verification errors precisely.

##### 2. Documentation Modernization
* **Passive Mode Guides**:
  * **User Guide (`fedcm-passive-mode.usage.md`)**: Rewrote for natural English, added clear definitions for Active vs. Passive UX modes, and structured the testing steps.
  * **Developer Guide (`fedcm-passive-mode.dev.md`)**: Added a JavaScript implementation example showing `navigator.credentials.get()` with `mode: 'passive'`, along with a structured best practices checklist (graceful degradation, verification, mediation control) and curated resource links.
* **Active Mode Guides**:
  * **User Guide (`fedcm-active-mode.usage.md`)**: Updated the testing instructions to remove references to the deleted Google sign-in button, instructing users specifically to click the **Sign-in with FedCM Demo IdP** button.
  * **Developer Guide (`fedcm-active-mode.dev.md`)**: Added an active mode JavaScript code walkthrough highlighting user gesture requirements, along with a best practices checklist and relevant resource guides.