### PR TITLE
Add /automatic-passkey-creation

### DIFF
--- a/prod.config.json
+++ b/prod.config.json
@@ -37,6 +37,7 @@
     "/signup-form",
     "/passkey-signup",
     "/signin-form",
+    "/automatic-passkey-creation",
     "/new-password",
     "/password",
     "/password-reauth",

--- a/src/client/pages/automatic-passkey-creation.ts
+++ b/src/client/pages/automatic-passkey-creation.ts
@@ -1,0 +1,47 @@
+/*
+ * @license
+ * Copyright 2026 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import '~project-sesame/client/layout';
+import {redirect, postForm, toast} from '~project-sesame/client/helpers/index';
+import {
+  capabilities,
+  registerCredential,
+} from '~project-sesame/client/helpers/publickey';
+
+postForm(
+  async () => {
+    if (capabilities?.conditionalCreate) {
+      try {
+        await registerCredential(false, true);
+      } catch (error: any) {
+        if (error.name === 'InvalidStateError') {
+          console.info('A passkey is already registered for the user.');
+        } else if (error.name === 'NotAllowedError') {
+          console.info(
+            "Passkey was not created because the password didn't match the one in the password manager."
+          );
+        } else if (error.name !== 'AbortError') {
+          console.error(error);
+        }
+      }
+    }
+    await redirect('/home');
+  },
+  (error: Error) => {
+    toast(error.message);
+  }
+);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -271,6 +271,32 @@ app.get(
   }
 );
 
+/**
+ * Automatic Passkey Creation Page.
+ * @swagger
+ * /automatic-passkey-creation:
+ *   get:
+ *     summary: Automatic Passkey Creation
+ *     description: Renders the automatic passkey creation page.
+ *     tags: [Pages]
+ *     responses:
+ *       200:
+ *         description: HTML Page
+ *         content:
+ *           text/html:
+ *             schema:
+ *               type: string
+ */
+app.get(
+  '/automatic-passkey-creation',
+  pageAclCheck(PageType.SignIn),
+  (req: Request, res: Response): void => {
+    return res.render('automatic-passkey-creation.html', {
+      title: 'Automatic Passkey Creation',
+    });
+  }
+);
+
 app.get(
   '/new-password',
   pageAclCheck(PageType.SigningUp),

--- a/src/server/libs/session.ts
+++ b/src/server/libs/session.ts
@@ -322,8 +322,22 @@ export function getSignInStatus(req: Request, res: Response): UserSignInStatus {
   return status;
 }
 
+/**
+ * Middleware factory for checking page-level Access Control Lists (ACL) based on user sign-in status.
+ * It enforces routing constraints for different page types (e.g., Sign-In, Sign-Up, Signed-In, Sensitive)
+ * and manages redirection flows to ensure users are in the correct authentication state.
+ *
+ * It also handles:
+ * - Feature-flag gating: Returns 404 if the page is not in the `config.enabled_pages` list.
+ * - Entrance path tracking: Records where the user started their auth flow to support correct post-auth redirection.
+ * - Re-authentication routing: Detects if a signed-in user is attempting to access a sign-in/sensitive page and redirects them to the appropriate re-auth or home path.
+ *
+ * @param pageType The required page ACL category (`PageType`) for the requested route.
+ * @returns An Express request handler function.
+ */
 export function pageAclCheck(pageType: PageType): RequestHandlerParams {
   return (req: Request, res: Response, next: NextFunction): void | any => {
+    // 1. Feature Flag / Gating: If enabled_pages is configured, reject any route not explicitly listed.
     if (
       config.enabled_pages &&
       !config.enabled_pages.includes(req.baseUrl + req.path)
@@ -332,34 +346,39 @@ export function pageAclCheck(pageType: PageType): RequestHandlerParams {
     }
 
     const {signin_status} = res.locals;
-
     const sessionService = new SessionService(req.session);
+
+    // 2. Enforce state transitions based on the requested PageType ACL
     if (pageType === PageType.SignUp) {
+      // Clear any stale sign-up flow state.
       sessionService.resetSigningUp();
+      // Signed-in users have no need to sign up again; redirect them to home.
       if (signin_status >= UserSignInStatus.SignedIn) {
-        // If the user is signed in, redirect to `/home`.
         return res.redirect(307, '/home');
       }
     } else if (pageType === PageType.SigningUp) {
+      // Redirect already signed-in users to home.
       if (signin_status >= UserSignInStatus.SignedIn) {
-        // If the user is signed in, redirect to `/home`.
         return res.redirect(307, '/home');
       }
+      // Users must start the sign-up process from the beginning (signup-form).
       if (signin_status < UserSignInStatus.SigningUp) {
-        // If the user has not started signing in, redirect to the original entrance.
         return res.redirect(307, '/signup-form');
       }
     } else if (pageType === PageType.SignIn) {
+      // Clear any stale sign-in flow state.
       sessionService.resetSigningIn();
+
       if (signin_status >= UserSignInStatus.SignedIn) {
         const queryParams = req.query;
         const search = new URLSearchParams(
           queryParams as Record<string, string>
         );
-        // If the user is already signed in...
+        // If already signed in, redirect to the appropriate re-authentication page.
+        // Password-based entrances go to password-reauth; others (e.g., passkeys) go to passkey-reauth.
         const entrance = sessionService.getEntrancePath();
         const url = new URL(config.origin);
-        if (entrance === '/signin-form') {
+        if (entrance === '/signin-form' || entrance === '/automatic-passkey-creation') {
           url.pathname = '/password-reauth';
         } else {
           url.pathname = '/passkey-reauth';
@@ -367,41 +386,43 @@ export function pageAclCheck(pageType: PageType): RequestHandlerParams {
         url.search = search.toString();
         return res.redirect(307, url.pathname + url.search);
       }
+      // Save the current page as the entrance path so we know where the user started.
       sessionService.setEntrancePath(req.path);
     } else if (pageType === PageType.FirstCredential) {
+      // Creating the first passkey after signing in requires an active sign-in flow.
       if (signin_status < UserSignInStatus.SigningIn) {
-        // If the user is not signing in, redirect to the original entrance.
         return res.redirect(307, sessionService.getEntrancePath());
       } else if (signin_status >= UserSignInStatus.SignedIn) {
-        // If the user is recently signed in, redirect to `/home`.
+        // If they are already fully signed in, redirect them to home.
         return res.redirect(307, '/home');
       }
     } else if (pageType === PageType.Reauth) {
+      // Re-authentication requires the user to be in the process of signing in.
       if (signin_status < UserSignInStatus.SigningIn) {
-        // If the user is not signing in, redirect to the original entrance.
         return res.redirect(307, sessionService.getEntrancePath());
       }
+      // If the user has already successfully authenticated recently, redirect them to home.
       if (signin_status >= UserSignInStatus.RecentlySignedIn) {
-        // If the user is recently signed in, redirect to `/home`.
         return res.redirect(307, '/home');
       }
     } else if (pageType === PageType.SignedIn) {
+      // Standard protected pages: Redirect unauthenticated users back to their original entrance.
       if (signin_status < UserSignInStatus.SignedIn) {
-        // If the user has not signed in yet, redirect to the original entrance.
         return res.redirect(307, sessionService.getEntrancePath());
       }
     } else if (pageType === PageType.Sensitive) {
+      // Highly sensitive pages (e.g., changing password or deleting account) require a recent sign-in.
+      // If the sign-in is stale or non-existent, redirect to the entrance with a return URL 'r'.
       if (signin_status < UserSignInStatus.RecentlySignedIn) {
-        // Construct the redirect path as `r`
         const url = new URL(sessionService.getEntrancePath(), config.origin);
         const search = new URLSearchParams({r: req.originalUrl});
         url.search = search.toString();
         logger.debug(url.toString());
 
-        // If the user has not signed in yet, redirect to the original entrance.
         return res.redirect(307, url.pathname + url.search);
       }
     }
+    // 3. Authorized: Allow the request to proceed to the route handler.
     return next();
   };
 }

--- a/src/server/libs/session.ts
+++ b/src/server/libs/session.ts
@@ -378,7 +378,10 @@ export function pageAclCheck(pageType: PageType): RequestHandlerParams {
         // Password-based entrances go to password-reauth; others (e.g., passkeys) go to passkey-reauth.
         const entrance = sessionService.getEntrancePath();
         const url = new URL(config.origin);
-        if (entrance === '/signin-form' || entrance === '/automatic-passkey-creation') {
+        if (
+          entrance === '/signin-form' ||
+          entrance === '/automatic-passkey-creation'
+        ) {
           url.pathname = '/password-reauth';
         } else {
           url.pathname = '/passkey-reauth';

--- a/src/shared/helps/automatic-passkey-creation.dev.md
+++ b/src/shared/helps/automatic-passkey-creation.dev.md
@@ -1,0 +1,48 @@
+<!--
+ Copyright 2026 Google Inc. All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License
+-->
+
+## Integrating automatic passkey creation
+
+Automatic passkey creation is implemented via the WebAuthn **Conditional
+Create** API. This API allows password managers to detect when a user signs in
+with a traditional password and offer to upgrade their account to a passkey on
+the spot. This drives passkey adoption by creating a passkey automatically at
+the exact moment they successfully authenticate, without requiring them to
+navigate to a settings page.
+
+Invoke `navigator.credentials.create()` with `mediation: "conditional"` soon
+after the user successfully authenticates with a traditional password (the
+duration depends on the browser). If you have a second step authentication,
+invoke it after the user successfully signed in.
+
+### Key integration conditions:
+
+- **Saved password:** A password must be saved in the browser's password
+  manager.
+- **Matching password:** The password entered by the user must match the one
+  stored in the password manager.
+- **No existing passkeys:** There must be no existing passkey for this account
+  in the password manager.
+- **Immediate invocation:** `navigator.credentials.create()` must be called
+  shortly after password authentication is completed.
+- **Ignore errors:** To let the user smoothly land on the homepage, gracefully
+  ignore errors caused by a conditional create call.
+- **User presence off:** The resulting credential has a `user presence` off.
+  Make sure you skip the `UP` flag check on the server side.
+
+### Learning resources
+
+- [Automatically create passkeys for your users using Conditional Create](https://developer.chrome.com/docs/identity/webauthn-conditional-create)

--- a/src/shared/helps/automatic-passkey-creation.usage.md
+++ b/src/shared/helps/automatic-passkey-creation.usage.md
@@ -1,0 +1,46 @@
+<!--
+ Copyright 2026 Google Inc. All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License
+-->
+
+## Automatic passkey creation
+
+On this page, you can experience a traditional form-based sign-in flow with
+**automatic passkey creation** that helps you transition to passkeys.
+
+### Prerequisites
+
+- **Browser support**: Automatic passkey creation requires a Chromium based
+  browser or Apple Safari.
+- **Saved credentials**: You must have a saved password for this site in your
+  browser's password manager in advance.
+- **No existing passkeys**: The browser's password manager must not already
+  contain a passkey for this account.
+
+### How to test it:
+
+- **Save a password first**: If you haven't already, sign up to this website (or
+  sign in and save a password to your browser's password manager).
+- **Sign in with your saved password**: Enter your saved username and matching
+  password, then click **Login**.
+- **Trigger the passkey upgrade**: Upon successful authentication, the browser
+  will detect that the entered password matches the saved one and automatically
+  create a new passkey.
+- **Find the dialog**: You'll be notified when a passkey is successfully
+  created.
+
+\* To test this successfully, the password you enter must match a password
+already saved in your browser's password manager for this site. The demo backend
+accepts any password to log you in, but the browser's password manager requires
+a matching saved password to trigger the passkey upgrade.

--- a/src/shared/views/automatic-passkey-creation.html
+++ b/src/shared/views/automatic-passkey-creation.html
@@ -1,0 +1,61 @@
+<!--
+ Copyright 2026 Google Inc. All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License
+-->
+
+<main class="content center">
+  <h2>Log in</h2>
+  <form id="form" method="POST" action="/auth/username-password" class="center">
+    <p class="instructions">
+      Don't have an account yet? <a href="/signup-form">Register now</a>
+    </p>
+    <mdui-text-field
+      type="text"
+      id="username"
+      name="username"
+      autocomplete="username "
+      label="username"
+      width="100"
+      variant="outlined"
+      autofocus
+    >
+    </mdui-text-field>
+    <mdui-text-field
+      type="password"
+      id="password"
+      name="password"
+      autocomplete="current-password"
+      label="password"
+      width="100"
+      variant="outlined"
+      autofocus
+    >
+      <mdui-button-icon
+        class="password-toggle"
+        toggle
+        slot="end-icon"
+        icon="visibility_off--outlined"
+        selected-icon="visibility--outlined"
+        selectable
+      >
+      </mdui-button-icon>
+    </mdui-text-field>
+    <mdui-button type="submit" variant="filled">Login</mdui-button>
+    <mdui-button href="#" variant="text">Forgot password?</mdui-button>
+    <p class="instructions">
+      This is a demo website. Please don't use a real email address or a real
+      password.
+    </p>
+  </form>
+</main>

--- a/src/shared/views/index.html
+++ b/src/shared/views/index.html
@@ -29,6 +29,8 @@
   <ul>
     {{#if (isPageEnabled '/signin-form')}}
     <li><a href="/signin-form">Sign-in Form</a></li>
+    {{/if}} {{#if (isPageEnabled '/automatic-passkey-creation')}}
+    <li><a href="/automatic-passkey-creation">Automatic Passkey Creation</a></li>
     {{/if}} {{#if (isPageEnabled '/passkey-form-autofill')}}
     <li><a href="/passkey-form-autofill">Passkey form autofill</a></li>
     {{/if}} {{#if (isPageEnabled '/passkey-one-button')}}


### PR DESCRIPTION
To simplify instructions in the helpers, remove automatic passkey upgrade from `/signin-form` page and create a new `/automatic-passkey-creation` page.