### PR TITLE
Fix: appending `__Secure-` twice to the cookie name

### DIFF
--- a/src/server/libs/session.ts
+++ b/src/server/libs/session.ts
@@ -264,9 +264,7 @@ export function initializeSession() {
     resave: true,
     saveUninitialized: false,
     proxy: true,
-    name: config.is_localhost
-      ? config.session_cookie_name
-      : `__Secure-${config.session_cookie_name}`,
+    name: config.session_cookie_name,
     store: new CustomFirestoreStore({
       dataset: store,
       kind: 'sessions',


### PR DESCRIPTION
`__Secure-` was added to the cookie name twice—at `config.ts` and `session.ts`. Removed the one in `session.ts`.

cc: @cy245 