### PR TITLE
Add a switch to toggle between usage help and development help on the helper dialog

### DIFF
--- a/src/client/helpers/index.ts
+++ b/src/client/helpers/index.ts
@@ -209,6 +209,9 @@ export async function post(
   }
 }
 
+let usageContent: string | undefined;
+let developContent: string | undefined;
+
 /**
  * Dialog controller
  */
@@ -269,8 +272,6 @@ export class SesameDialog {
 
   async setHelpMode(mode: 'usage' | 'develop'): Promise<void> {
     this.currentMode = mode;
-    const usageContent = $('#usage-help-content')?.textContent?.trim();
-    const developContent = $('#develop-help-content')?.textContent?.trim();
 
     const titleIcon = $('#dialog-title-icon') as any;
     const toggleBtn = $('#dialog-toggle-help-btn') as any;
@@ -441,8 +442,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const usageHelpBtn = $('#usage-help');
   const developHelpBtn = $('#develop-help');
   const helpOnPageLoad = $('#help-on-page-load');
-  const usageContent = $('#usage-help-content')?.textContent?.trim();
-  const developContent = $('#develop-help-content')?.textContent?.trim();
+  usageContent = $('#usage-help-content')?.textContent?.trim();
+  developContent = $('#develop-help-content')?.textContent?.trim();
 
   if (helpOnPageLoad) {
     helpOnPageLoad.addEventListener('change', () => {

--- a/src/client/helpers/index.ts
+++ b/src/client/helpers/index.ts
@@ -214,6 +214,7 @@ export async function post(
  */
 export class SesameDialog {
   dialog: HTMLDialogElement;
+  currentMode: 'usage' | 'develop' | null = null;
 
   constructor() {
     this.dialog = $('#dialog') as HTMLDialogElement;
@@ -244,6 +245,18 @@ export class SesameDialog {
         this.close();
       });
     }
+
+    // Toggle help button event listener
+    const toggleBtn = $('#dialog-toggle-help-btn');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', () => {
+        if (this.currentMode === 'usage') {
+          this.setHelpMode('develop');
+        } else if (this.currentMode === 'develop') {
+          this.setHelpMode('usage');
+        }
+      });
+    }
   }
 
   set(headline: string, description = ''): void {
@@ -252,6 +265,33 @@ export class SesameDialog {
 
     const descriptionElement = $('#dialog-content');
     if (descriptionElement) descriptionElement.innerHTML = description;
+  }
+
+  async setHelpMode(mode: 'usage' | 'develop'): Promise<void> {
+    this.currentMode = mode;
+    const usageContent = $('#usage-help-content')?.textContent?.trim();
+    const developContent = $('#develop-help-content')?.textContent?.trim();
+
+    const titleIcon = $('#dialog-title-icon') as any;
+    const toggleBtn = $('#dialog-toggle-help-btn') as any;
+
+    if (mode === 'usage') {
+      if (titleIcon) titleIcon.name = 'help_center--outlined';
+      if (toggleBtn) {
+        toggleBtn.icon = 'integration_instructions--outlined';
+        toggleBtn.title = 'Switch to development help';
+      }
+      const desc = usageContent ? await marked.parse(usageContent) : '';
+      this.set("What's this page?", desc);
+    } else if (mode === 'develop') {
+      if (titleIcon) titleIcon.name = 'integration_instructions--outlined';
+      if (toggleBtn) {
+        toggleBtn.icon = 'help_center--outlined';
+        toggleBtn.title = 'Switch to usage help';
+      }
+      const desc = developContent ? await marked.parse(developContent) : '';
+      this.set('How do I integrate?', desc);
+    }
   }
 
   show(): void {
@@ -422,8 +462,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   async function displayUsageHelp() {
-    const mkDesc = await marked.parse(usageContent);
-    dialog.set("What's this page?", mkDesc);
+    await dialog.setHelpMode('usage');
     dialog.show();
   }
 
@@ -436,8 +475,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   if (developHelpBtn && developContent) {
     developHelpBtn.addEventListener('click', async () => {
-      const mkDesc = await marked.parse(developContent);
-      dialog.set('How do I integrate?', mkDesc);
+      await dialog.setHelpMode('develop');
       dialog.show();
     });
   }

--- a/src/client/layout.html
+++ b/src/client/layout.html
@@ -45,11 +45,11 @@
     <mdui-bottom-app-bar style="z-index: 900">
       {{#if usage_help}}
       <script id="usage-help-content" type="text/markdown">{{{usage_help}}}</script>
-      <mdui-button-icon id="usage-help" icon="help_center--outlined"></mdui-button-icon>
+      <mdui-button-icon id="usage-help" icon="help_center--outlined" title="Usage help"></mdui-button-icon>
       {{/if}}
       {{#if develop_help}}
       <script id="develop-help-content" type="text/markdown">{{{develop_help}}}</script>
-      <mdui-button-icon id="develop-help" icon="integration_instructions--outlined"></mdui-button-icon>
+      <mdui-button-icon id="develop-help" icon="integration_instructions--outlined" title="Development help"></mdui-button-icon>
       {{/if}}
       <div style="flex-grow: 1"></div>
       <mdui-checkbox id="help-on-page-load" icon="close--outlined">Show help on page load</mdui-checkbox>
@@ -57,8 +57,18 @@
     <dialog id="dialog" closedby="any" aria-labelledby="dialog-headline">
       <div class="dialog-container">
         <div class="dialog-header">
-          <h2 id="dialog-headline"></h2>
-          <button id="dialog-close-btn" type="button" aria-label="Close dialog">&times;</button>
+          <div class="dialog-title-container">
+            <mdui-icon id="dialog-title-icon"></mdui-icon>
+            <h2 id="dialog-headline"></h2>
+          </div>
+          <div class="dialog-header-actions">
+            {{#if usage_help}}
+              {{#if develop_help}}
+              <mdui-button-icon id="dialog-toggle-help-btn"></mdui-button-icon>
+              {{/if}}
+            {{/if}}
+            <mdui-button-icon id="dialog-close-btn" type="button" aria-label="Close dialog" icon="close--outlined"></mdui-button-icon>
+          </div>
         </div>
         <div class="dialog-body" id="dialog-content"></div>
       </div>

--- a/src/client/layout.ts
+++ b/src/client/layout.ts
@@ -34,3 +34,4 @@ import 'mdui/components/list-item.js';
 import 'mdui/components/checkbox.js';
 import 'mdui/components/snackbar.js';
 import 'mdui/components/linear-progress.js';
+import 'mdui/components/icon.js';

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -264,10 +264,27 @@ div[slot='appContent'] {
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
     padding-bottom: 12px;
 
-    h2 {
-      margin: 0;
-      font-size: 20px;
-      font-weight: 500;
+    .dialog-title-container {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+
+      mdui-icon {
+        font-size: 24px;
+        color: var(--mdui-theme-on-surface);
+      }
+
+      h2 {
+        margin: 0;
+        font-size: 20px;
+        font-weight: 500;
+      }
+    }
+
+    .dialog-header-actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
     }
 
     #dialog-close-btn {


### PR DESCRIPTION
This PR adds a button to switch between the usage help and the development help on the helper dialog.